### PR TITLE
Fix: Extract AbstractConfigTestCase

### DIFF
--- a/test/Unit/AbstractConfigTestCase.php
+++ b/test/Unit/AbstractConfigTestCase.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/php-cs-fixer-config
+ */
+
+namespace Localheinz\PhpCsFixer\Config\Test\Unit;
+
+use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Fixer;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet;
+use PHPUnit\Framework;
+
+abstract class AbstractConfigTestCase extends Framework\TestCase
+{
+    final public function testIsFinal()
+    {
+        $reflection = new \ReflectionClass($this->className());
+
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    final public function testImplementsConfigInterface()
+    {
+        $reflection = new \ReflectionClass($this->className());
+
+        $this->assertTrue($reflection->implementsInterface(ConfigInterface::class));
+    }
+
+    final public function testDefaults()
+    {
+        $config = $this->createConfig();
+
+        $this->assertSame($this->name(), $config->getName());
+        $this->assertTrue($config->getRiskyAllowed());
+        $this->assertTrue($config->getUsingCache());
+    }
+
+    final public function testHasRules()
+    {
+        $this->assertEquals($this->rules(), $this->createConfig()->getRules());
+    }
+
+    final public function testAllConfiguredRulesAreBuiltIn()
+    {
+        $fixersNotBuiltIn = \array_diff(
+            $this->configuredFixers(),
+            $this->builtInFixers()
+        );
+
+        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
+            'Failed to assert that fixers for the rules "%s" are built in',
+            \implode('", "', $fixersNotBuiltIn)
+        ));
+    }
+
+    final public function testAllBuiltInRulesAreConfigured()
+    {
+        $fixersWithoutConfiguration = \array_diff(
+            $this->builtInFixers(),
+            $this->configuredFixers()
+        );
+
+        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
+            'Failed to assert that built-in fixers for the rules "%s" are configured',
+            \implode('", "', $fixersWithoutConfiguration)
+        ));
+    }
+
+    /**
+     * @dataProvider providerInvalidHeader
+     *
+     * @param $header
+     */
+    final public function testConstructorRejectsInvalidHeader($header)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createConfig($header);
+    }
+
+    /**
+     * @return \Generator
+     */
+    final public function providerInvalidHeader()
+    {
+        $values = [
+            'array' => [],
+            'boolean-true' => true,
+            'boolean-false' => false,
+            'float' => 3.14,
+            'integer' => 90001,
+            'string-empty' => '',
+            'string-with-line-feed-only' => "\n",
+            'string-with-spaces-only' => ' ',
+            'string-with-tab-only' => "\t",
+            'object' => new \stdClass(),
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    final public function testHeaderCommentFixerIsDisabledByDefault()
+    {
+        $rules = $this->createConfig()->getRules();
+
+        $this->assertArrayHasKey('header_comment', $rules);
+        $this->assertFalse($rules['header_comment']);
+    }
+
+    final public function testHeaderCommentFixerIsEnabledIfHeaderIsProvided()
+    {
+        $header = 'foo';
+
+        $rules = $this->createConfig($header)->getRules();
+
+        $this->assertArrayHasKey('header_comment', $rules);
+
+        $expected = [
+            'commentType' => 'PHPDoc',
+            'header' => $header,
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+
+        $this->assertSame($expected, $rules['header_comment']);
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function className();
+
+    /**
+     * @return array
+     */
+    abstract protected function rules();
+
+    /**
+     * @return string
+     */
+    abstract protected function name();
+
+    /**
+     * @param string $header
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return ConfigInterface
+     */
+    final protected function createConfig($header = null)
+    {
+        $reflection = new \ReflectionClass($this->className());
+
+        return $reflection->newInstance($header);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function builtInFixers()
+    {
+        static $builtInFixers;
+
+        if (null === $builtInFixers) {
+            $fixerFactory = FixerFactory::create();
+            $fixerFactory->registerBuiltInFixers();
+
+            $builtInFixers = \array_map(function (Fixer\FixerInterface $fixer) {
+                return $fixer->getName();
+            }, $fixerFactory->getFixers());
+        }
+
+        return $builtInFixers;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function configuredFixers()
+    {
+        /**
+         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
+         *
+         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
+         */
+        $rules = \array_map(function () {
+            return true;
+        }, $this->createConfig()->getRules());
+
+        return \array_keys(RuleSet::create($rules)->getRules());
+    }
+}

--- a/test/Unit/Php56Test.php
+++ b/test/Unit/Php56Test.php
@@ -12,179 +12,20 @@
 namespace Localheinz\PhpCsFixer\Config\Test\Unit;
 
 use Localheinz\PhpCsFixer\Config\Php56;
-use PhpCsFixer\ConfigInterface;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
-use PhpCsFixer\RuleSet;
-use PHPUnit\Framework;
 
-final class Php56Test extends Framework\TestCase
+final class Php56Test extends AbstractConfigTestCase
 {
-    public function testIsFinal()
+    protected function className()
     {
-        $reflection = new \ReflectionClass(Php56::class);
-
-        $this->assertTrue($reflection->isFinal());
+        return Php56::class;
     }
 
-    public function testImplementsConfigInterface()
+    protected function name()
     {
-        $reflection = new \ReflectionClass(Php56::class);
-
-        $this->assertTrue($reflection->implementsInterface(ConfigInterface::class));
+        return 'localheinz (PHP 5.6)';
     }
 
-    public function testDefaults()
-    {
-        $config = new Php56();
-
-        $this->assertSame('localheinz (PHP 5.6)', $config->getName());
-        $this->assertTrue($config->getRiskyAllowed());
-        $this->assertTrue($config->getUsingCache());
-    }
-
-    public function testHasRules()
-    {
-        $config = new Php56();
-
-        $this->assertEquals($this->expectedRules(), $config->getRules());
-    }
-
-    public function testAllConfiguredRulesAreBuiltIn()
-    {
-        $fixersNotBuiltIn = \array_diff(
-            $this->configuredFixers(),
-            $this->builtInFixers()
-        );
-
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
-            'Failed to assert that fixers for the rules "%s" are built in',
-            \implode('", "', $fixersNotBuiltIn)
-        ));
-    }
-
-    public function testAllBuiltInRulesAreConfigured()
-    {
-        $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
-            $this->configuredFixers()
-        );
-
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
-            'Failed to assert that built-in fixers for the rules "%s" are configured',
-            \implode('", "', $fixersWithoutConfiguration)
-        ));
-    }
-
-    /**
-     * @dataProvider providerInvalidHeader
-     *
-     * @param $header
-     */
-    public function testConstructorRejectsInvalidHeader($header)
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        new Php56($header);
-    }
-
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidHeader()
-    {
-        $values = [
-            'boolean-true' => true,
-            'boolean-false' => false,
-            'float' => 3.14,
-            'integer' => 90001,
-            'array' => [],
-            'object' => new \stdClass(),
-            'empty-string' => '',
-            'string-with-spaces-only' => ' ',
-            'string-with-line-feed-only' => "\n",
-            'string-with-tab-only' => "\t",
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
-    }
-
-    public function testHeaderCommentFixerIsDisabledByDefault()
-    {
-        $config = new Php56();
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
-    }
-
-    public function testHeaderCommentFixerIsEnabledIfHeaderProvided()
-    {
-        $header = 'foo';
-
-        $config = new Php56($header);
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-
-        $expected = [
-            'commentType' => 'PHPDoc',
-            'header' => $header,
-            'location' => 'after_declare_strict',
-            'separate' => 'both',
-        ];
-
-        $this->assertSame($expected, $rules['header_comment']);
-    }
-
-    /**
-     * @return string[]
-     */
-    private function builtInFixers()
-    {
-        static $builtInFixers;
-
-        if (null === $builtInFixers) {
-            $fixerFactory = FixerFactory::create();
-            $fixerFactory->registerBuiltInFixers();
-
-            $builtInFixers = \array_map(function (FixerInterface $fixer) {
-                return $fixer->getName();
-            }, $fixerFactory->getFixers());
-        }
-
-        return $builtInFixers;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function configuredFixers()
-    {
-        $config = new Php56();
-
-        /**
-         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
-         *
-         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
-         */
-        $rules = \array_map(function () {
-            return true;
-        }, $config->getRules());
-
-        return \array_keys(RuleSet::create($rules)->getRules());
-    }
-
-    /**
-     * @return array
-     */
-    private function expectedRules()
+    protected function rules()
     {
         return [
             '@PSR2' => true,

--- a/test/Unit/Php70Test.php
+++ b/test/Unit/Php70Test.php
@@ -12,179 +12,20 @@
 namespace Localheinz\PhpCsFixer\Config\Test\Unit;
 
 use Localheinz\PhpCsFixer\Config\Php70;
-use PhpCsFixer\ConfigInterface;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
-use PhpCsFixer\RuleSet;
-use PHPUnit\Framework;
 
-final class Php70Test extends Framework\TestCase
+final class Php70Test extends AbstractConfigTestCase
 {
-    public function testIsFinal()
+    protected function className()
     {
-        $reflection = new \ReflectionClass(Php70::class);
-
-        $this->assertTrue($reflection->isFinal());
+        return Php70::class;
     }
 
-    public function testImplementsConfigInterface()
+    protected function name()
     {
-        $reflection = new \ReflectionClass(Php70::class);
-
-        $this->assertTrue($reflection->implementsInterface(ConfigInterface::class));
+        return 'localheinz (PHP 7.0)';
     }
 
-    public function testDefaults()
-    {
-        $config = new Php70();
-
-        $this->assertSame('localheinz (PHP 7.0)', $config->getName());
-        $this->assertTrue($config->getRiskyAllowed());
-        $this->assertTrue($config->getUsingCache());
-    }
-
-    public function testHasRules()
-    {
-        $config = new Php70();
-
-        $this->assertEquals($this->expectedRules(), $config->getRules());
-    }
-
-    public function testAllConfiguredRulesAreBuiltIn()
-    {
-        $fixersNotBuiltIn = \array_diff(
-            $this->configuredFixers(),
-            $this->builtInFixers()
-        );
-
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
-            'Failed to assert that fixers for the rules "%s" are built in',
-            \implode('", "', $fixersNotBuiltIn)
-        ));
-    }
-
-    public function testAllBuiltInRulesAreConfigured()
-    {
-        $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
-            $this->configuredFixers()
-        );
-
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
-            'Failed to assert that built-in fixers for the rules "%s" are configured',
-            \implode('", "', $fixersWithoutConfiguration)
-        ));
-    }
-
-    /**
-     * @dataProvider providerInvalidHeader
-     *
-     * @param $header
-     */
-    public function testConstructorRejectsInvalidHeader($header)
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        new Php70($header);
-    }
-
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidHeader()
-    {
-        $values = [
-            'boolean-true' => true,
-            'boolean-false' => false,
-            'float' => 3.14,
-            'integer' => 90001,
-            'array' => [],
-            'object' => new \stdClass(),
-            'empty-string' => '',
-            'string-with-spaces-only' => ' ',
-            'string-with-line-feed-only' => "\n",
-            'string-with-tab-only' => "\t",
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
-    }
-
-    public function testHeaderCommentFixerIsDisabledByDefault()
-    {
-        $config = new Php70();
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
-    }
-
-    public function testHeaderCommentFixerIsEnabledIfHeaderProvided()
-    {
-        $header = 'foo';
-
-        $config = new Php70($header);
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-
-        $expected = [
-            'commentType' => 'PHPDoc',
-            'header' => $header,
-            'location' => 'after_declare_strict',
-            'separate' => 'both',
-        ];
-
-        $this->assertSame($expected, $rules['header_comment']);
-    }
-
-    /**
-     * @return string[]
-     */
-    private function builtInFixers()
-    {
-        static $builtInFixers;
-
-        if (null === $builtInFixers) {
-            $fixerFactory = FixerFactory::create();
-            $fixerFactory->registerBuiltInFixers();
-
-            $builtInFixers = \array_map(function (FixerInterface $fixer) {
-                return $fixer->getName();
-            }, $fixerFactory->getFixers());
-        }
-
-        return $builtInFixers;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function configuredFixers()
-    {
-        $config = new Php70();
-
-        /**
-         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
-         *
-         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
-         */
-        $rules = \array_map(function () {
-            return true;
-        }, $config->getRules());
-
-        return \array_keys(RuleSet::create($rules)->getRules());
-    }
-
-    /**
-     * @return array
-     */
-    private function expectedRules()
+    protected function rules()
     {
         return [
             '@PSR2' => true,

--- a/test/Unit/Php71Test.php
+++ b/test/Unit/Php71Test.php
@@ -12,179 +12,20 @@
 namespace Localheinz\PhpCsFixer\Config\Test\Unit;
 
 use Localheinz\PhpCsFixer\Config\Php71;
-use PhpCsFixer\ConfigInterface;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
-use PhpCsFixer\RuleSet;
-use PHPUnit\Framework;
 
-final class Php71Test extends Framework\TestCase
+final class Php71Test extends AbstractConfigTestCase
 {
-    public function testIsFinal()
+    protected function className()
     {
-        $reflection = new \ReflectionClass(Php71::class);
-
-        $this->assertTrue($reflection->isFinal());
+        return Php71::class;
     }
 
-    public function testImplementsConfigInterface()
+    protected function name()
     {
-        $reflection = new \ReflectionClass(Php71::class);
-
-        $this->assertTrue($reflection->implementsInterface(ConfigInterface::class));
+        return 'localheinz (PHP 7.1)';
     }
 
-    public function testDefaults()
-    {
-        $config = new Php71();
-
-        $this->assertSame('localheinz (PHP 7.1)', $config->getName());
-        $this->assertTrue($config->getRiskyAllowed());
-        $this->assertTrue($config->getUsingCache());
-    }
-
-    public function testHasRules()
-    {
-        $config = new Php71();
-
-        $this->assertEquals($this->expectedRules(), $config->getRules());
-    }
-
-    public function testAllConfiguredRulesAreBuiltIn()
-    {
-        $fixersNotBuiltIn = \array_diff(
-            $this->configuredFixers(),
-            $this->builtInFixers()
-        );
-
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
-            'Failed to assert that fixers for the rules "%s" are built in',
-            \implode('", "', $fixersNotBuiltIn)
-        ));
-    }
-
-    public function testAllBuiltInRulesAreConfigured()
-    {
-        $fixersWithoutConfiguration = \array_diff(
-            $this->builtInFixers(),
-            $this->configuredFixers()
-        );
-
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
-            'Failed to assert that built-in fixers for the rules "%s" are configured',
-            \implode('", "', $fixersWithoutConfiguration)
-        ));
-    }
-
-    /**
-     * @dataProvider providerInvalidHeader
-     *
-     * @param $header
-     */
-    public function testConstructorRejectsInvalidHeader($header)
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        new Php71($header);
-    }
-
-    /**
-     * @return \Generator
-     */
-    public function providerInvalidHeader()
-    {
-        $values = [
-            'boolean-true' => true,
-            'boolean-false' => false,
-            'float' => 3.14,
-            'integer' => 90001,
-            'array' => [],
-            'object' => new \stdClass(),
-            'empty-string' => '',
-            'string-with-spaces-only' => ' ',
-            'string-with-line-feed-only' => "\n",
-            'string-with-tab-only' => "\t",
-        ];
-
-        foreach ($values as $key => $value) {
-            yield $key => [
-                $value,
-            ];
-        }
-    }
-
-    public function testHeaderCommentFixerIsDisabledByDefault()
-    {
-        $config = new Php71();
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
-    }
-
-    public function testHeaderCommentFixerIsEnabledIfHeaderProvided()
-    {
-        $header = 'foo';
-
-        $config = new Php71($header);
-
-        $rules = $config->getRules();
-
-        $this->assertArrayHasKey('header_comment', $rules);
-
-        $expected = [
-            'commentType' => 'PHPDoc',
-            'header' => $header,
-            'location' => 'after_declare_strict',
-            'separate' => 'both',
-        ];
-
-        $this->assertSame($expected, $rules['header_comment']);
-    }
-
-    /**
-     * @return string[]
-     */
-    private function builtInFixers()
-    {
-        static $builtInFixers;
-
-        if (null === $builtInFixers) {
-            $fixerFactory = FixerFactory::create();
-            $fixerFactory->registerBuiltInFixers();
-
-            $builtInFixers = \array_map(function (FixerInterface $fixer) {
-                return $fixer->getName();
-            }, $fixerFactory->getFixers());
-        }
-
-        return $builtInFixers;
-    }
-
-    /**
-     * @return string[]
-     */
-    private function configuredFixers()
-    {
-        $config = new Php71();
-
-        /**
-         * RuleSet::create() removes disabled fixers, to let's just enable them to make sure they not removed.
-         *
-         * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
-         */
-        $rules = \array_map(function () {
-            return true;
-        }, $config->getRules());
-
-        return \array_keys(RuleSet::create($rules)->getRules());
-    }
-
-    /**
-     * @return array
-     */
-    private function expectedRules()
+    protected function rules()
     {
         return [
             '@PSR2' => true,


### PR DESCRIPTION
This PR

* [x] extracts an `AbstractConfigTestCase`