### PR TITLE
Enhancement: Throw RuntimeException if current PHP version is too low

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -18,10 +18,20 @@ final class Factory
     /**
      * @param RuleSet $rules
      *
+     * @throws \RuntimeException
+     *
      * @return Config
      */
     public static function fromRuleSet(RuleSet $rules)
     {
+        if (PHP_VERSION_ID < $rules->targetPhpVersion()) {
+            throw new \RuntimeException(\sprintf(
+                'Current PHP version "%s is less than targeted PHP version "%s".',
+                PHP_VERSION_ID,
+                $rules->targetPhpVersion()
+            ));
+        }
+
         $config = new Config($rules->name());
 
         $config->setRiskyAllowed(true);

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -22,4 +22,9 @@ interface RuleSet
      * @return array
      */
     public function rules();
+
+    /**
+     * @return int
+     */
+    public function targetPhpVersion();
 }

--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -29,6 +29,11 @@ abstract class AbstractRuleSet implements RuleSet
     protected $rules = [];
 
     /**
+     * @var int
+     */
+    protected $targetPhpVersion;
+
+    /**
      * @param string $header
      *
      * @throws \InvalidArgumentException
@@ -69,5 +74,10 @@ abstract class AbstractRuleSet implements RuleSet
     final public function rules()
     {
         return $this->rules;
+    }
+
+    final public function targetPhpVersion()
+    {
+        return $this->targetPhpVersion;
     }
 }

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -156,4 +156,6 @@ final class Php56 extends AbstractRuleSet
         ],
         'whitespace_after_comma_in_array' => true,
     ];
+
+    protected $targetPhpVersion = 50600;
 }

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -156,4 +156,6 @@ final class Php70 extends AbstractRuleSet
         ],
         'whitespace_after_comma_in_array' => true,
     ];
+
+    protected $targetPhpVersion = 70000;
 }

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -157,4 +157,6 @@ final class Php71 extends AbstractRuleSet
         ],
         'whitespace_after_comma_in_array' => true,
     ];
+
+    protected $targetPhpVersion = 70100;
 }

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -39,6 +39,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
         $this->assertSame($this->name(), $ruleSet->name());
         $this->assertEquals($this->rules(), $ruleSet->rules());
+        $this->assertEquals($this->targetPhpVersion(), $ruleSet->targetPhpVersion());
     }
 
     final public function testAllConfiguredRulesAreBuiltIn()
@@ -136,14 +137,19 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     abstract protected function className();
 
     /**
+     * @return string
+     */
+    abstract protected function name();
+
+    /**
      * @return array
      */
     abstract protected function rules();
 
     /**
-     * @return string
+     * @return int
      */
-    abstract protected function name();
+    abstract protected function targetPhpVersion();
 
     /**
      * @param string $header

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -169,4 +169,9 @@ final class Php56Test extends AbstractRuleSetTestCase
             'whitespace_after_comma_in_array' => true,
         ];
     }
+
+    protected function targetPhpVersion()
+    {
+        return 50600;
+    }
 }

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -169,4 +169,9 @@ final class Php70Test extends AbstractRuleSetTestCase
             'whitespace_after_comma_in_array' => true,
         ];
     }
+
+    protected function targetPhpVersion()
+    {
+        return 70000;
+    }
 }

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -170,4 +170,9 @@ final class Php71Test extends AbstractRuleSetTestCase
             'whitespace_after_comma_in_array' => true,
         ];
     }
+
+    protected function targetPhpVersion()
+    {
+        return 70100;
+    }
 }


### PR DESCRIPTION
This PR

* [x] throws a `RuntimeException` if the current PHP version is lower than the PHP version targeted by a rule set