### PR TITLE
Fix: Rename parameter and test method

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,26 +16,26 @@ use PhpCsFixer\Config;
 final class Factory
 {
     /**
-     * @param RuleSet $rules
+     * @param RuleSet $ruleSet
      *
      * @throws \RuntimeException
      *
      * @return Config
      */
-    public static function fromRuleSet(RuleSet $rules)
+    public static function fromRuleSet(RuleSet $ruleSet)
     {
-        if (PHP_VERSION_ID < $rules->targetPhpVersion()) {
+        if (PHP_VERSION_ID < $ruleSet->targetPhpVersion()) {
             throw new \RuntimeException(\sprintf(
                 'Current PHP version "%s is less than targeted PHP version "%s".',
                 PHP_VERSION_ID,
-                $rules->targetPhpVersion()
+                $ruleSet->targetPhpVersion()
             ));
         }
 
-        $config = new Config($rules->name());
+        $config = new Config($ruleSet->name());
 
         $config->setRiskyAllowed(true);
-        $config->setRules($rules->rules());
+        $config->setRules($ruleSet->rules());
 
         return $config;
     }

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -24,7 +24,7 @@ final class FactoryTest extends Framework\TestCase
         $this->assertTrue($reflection->isFinal());
     }
 
-    public function testFromRulesThrowsRuntimeExceptionIfCurrentPhpVersionIsLessThanTargetPhpVersion()
+    public function testFromRuleSetThrowsRuntimeExceptionIfCurrentPhpVersionIsLessThanTargetPhpVersion()
     {
         $targetPhpVersion = PHP_VERSION_ID + 1;
 
@@ -58,7 +58,7 @@ final class FactoryTest extends Framework\TestCase
      *
      * @param $targetPhpVersion
      */
-    public function testFromRulesCreatesConfig($targetPhpVersion)
+    public function testFromRuleSetCreatesConfig($targetPhpVersion)
     {
         $name = 'foobarbaz';
 


### PR DESCRIPTION
This PR

* [x] renames a parameter and a test method

Follows #5.