### PR TITLE
Fix: Remove composer.lock in composer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 it: cs test
 
 composer:
+	rm -rf composer.lock
 	composer self-update
 	composer validate
 	composer update


### PR DESCRIPTION
This PR

* [x] removes `composer.lock` as first in `composer` target of `Makefile`