### PR TITLE
Fix: No need to specify --prefer-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ cs: composer
 
 test: composer
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
-	composer update --prefer-dist --prefer-lowest
+	composer update --prefer-lowest
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml


### PR DESCRIPTION
This PR

* [x] removes `--prefer-dist` when installing dependencies in `Makefile`

💁‍♂️ It's already configured in [`composer.json`](https://github.com/localheinz/php-cs-fixer-config/blob/8ae2d8a9ef2676021caef85b09801295ccfd6478/composer.json#L13).