### PR TITLE
Fix: Disable declare_strict_types fixer in Php56 rule set

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -33,7 +33,7 @@ final class Php56 extends AbstractRuleSet
             'spacing' => 'one',
         ],
         'declare_equal_normalize' => true,
-        'declare_strict_types' => true,
+        'declare_strict_types' => false,
         'dir_constant' => true,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -45,7 +45,7 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'spacing' => 'one',
             ],
             'declare_equal_normalize' => true,
-            'declare_strict_types' => true,
+            'declare_strict_types' => false,
             'dir_constant' => true,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] disables the `declare_strict_types` fixer in the `Php56` rule set