### PR TITLE
Enhancement: Enable doctrine_annotation_braces fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -35,7 +35,9 @@ final class Php56 extends AbstractRuleSet
         'declare_equal_normalize' => true,
         'declare_strict_types' => false,
         'dir_constant' => true,
-        'doctrine_annotation_braces' => false,
+        'doctrine_annotation_braces' => [
+            'syntax' => 'without_braces',
+        ],
         'doctrine_annotation_indentation' => false,
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -35,7 +35,9 @@ final class Php70 extends AbstractRuleSet
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
-        'doctrine_annotation_braces' => false,
+        'doctrine_annotation_braces' => [
+            'syntax' => 'without_braces',
+        ],
         'doctrine_annotation_indentation' => false,
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -35,7 +35,9 @@ final class Php71 extends AbstractRuleSet
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
-        'doctrine_annotation_braces' => false,
+        'doctrine_annotation_braces' => [
+            'syntax' => 'without_braces',
+        ],
         'doctrine_annotation_indentation' => false,
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -47,7 +47,9 @@ final class Php56Test extends AbstractRuleSetTestCase
             'declare_equal_normalize' => true,
             'declare_strict_types' => false,
             'dir_constant' => true,
-            'doctrine_annotation_braces' => false,
+            'doctrine_annotation_braces' => [
+                'syntax' => 'without_braces',
+            ],
             'doctrine_annotation_indentation' => false,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -47,7 +47,9 @@ final class Php70Test extends AbstractRuleSetTestCase
             'declare_equal_normalize' => true,
             'declare_strict_types' => true,
             'dir_constant' => true,
-            'doctrine_annotation_braces' => false,
+            'doctrine_annotation_braces' => [
+                'syntax' => 'without_braces',
+            ],
             'doctrine_annotation_indentation' => false,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -47,7 +47,9 @@ final class Php71Test extends AbstractRuleSetTestCase
             'declare_equal_normalize' => true,
             'declare_strict_types' => true,
             'dir_constant' => true,
-            'doctrine_annotation_braces' => false,
+            'doctrine_annotation_braces' => [
+                'syntax' => 'without_braces',
+            ],
             'doctrine_annotation_indentation' => false,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,


### PR DESCRIPTION
This PR

* [x] enables the `doctrine_annotation_braces` fixer

Follows #15.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**doctrine_annotation_braces**
>
>Doctrine annotations without arguments must use the configured syntax.
