### PR TITLE
Enhancement: Enable doctrine_annotation_indentation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -38,7 +38,7 @@ final class Php56 extends AbstractRuleSet
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],
-        'doctrine_annotation_indentation' => false,
+        'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -38,7 +38,7 @@ final class Php70 extends AbstractRuleSet
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],
-        'doctrine_annotation_indentation' => false,
+        'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -38,7 +38,7 @@ final class Php71 extends AbstractRuleSet
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],
-        'doctrine_annotation_indentation' => false,
+        'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -50,7 +50,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'doctrine_annotation_braces' => [
                 'syntax' => 'without_braces',
             ],
-            'doctrine_annotation_indentation' => false,
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -50,7 +50,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'doctrine_annotation_braces' => [
                 'syntax' => 'without_braces',
             ],
-            'doctrine_annotation_indentation' => false,
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -50,7 +50,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'doctrine_annotation_braces' => [
                 'syntax' => 'without_braces',
             ],
-            'doctrine_annotation_indentation' => false,
+            'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] enables the `doctrine_annotation_indentation` fixer

Follows #15.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**doctrine_annotation_indentation**

>Doctrine annotations must be indented with four spaces.