### PR TITLE
Enhancement: Enable doctrine_annotation_spaces fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -39,7 +39,7 @@ final class Php56 extends AbstractRuleSet
             'syntax' => 'without_braces',
         ],
         'doctrine_annotation_indentation' => true,
-        'doctrine_annotation_spaces' => false,
+        'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,
         'function_to_constant' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -39,7 +39,7 @@ final class Php70 extends AbstractRuleSet
             'syntax' => 'without_braces',
         ],
         'doctrine_annotation_indentation' => true,
-        'doctrine_annotation_spaces' => false,
+        'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,
         'function_to_constant' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -39,7 +39,7 @@ final class Php71 extends AbstractRuleSet
             'syntax' => 'without_braces',
         ],
         'doctrine_annotation_indentation' => true,
-        'doctrine_annotation_spaces' => false,
+        'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,
         'function_to_constant' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -51,7 +51,7 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'syntax' => 'without_braces',
             ],
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false,
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,
             'function_to_constant' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -51,7 +51,7 @@ final class Php70Test extends AbstractRuleSetTestCase
                 'syntax' => 'without_braces',
             ],
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false,
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,
             'function_to_constant' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -51,7 +51,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'syntax' => 'without_braces',
             ],
             'doctrine_annotation_indentation' => true,
-            'doctrine_annotation_spaces' => false,
+            'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,
             'function_to_constant' => false,


### PR DESCRIPTION
This PR

* [x] enables the `doctrine_annotation_spaces` fixer

Follows #15.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**doctrine_annotation_spaces**

>Fixes spaces in Doctrine annotations.