### PR TITLE
Enhancement: Enable function_to_constant fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -42,7 +42,7 @@ final class Php56 extends AbstractRuleSet
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'general_phpdoc_annotation_remove' => false,
         'hash_to_slash_comment' => true,
         'header_comment' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -42,7 +42,7 @@ final class Php70 extends AbstractRuleSet
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'general_phpdoc_annotation_remove' => false,
         'hash_to_slash_comment' => true,
         'header_comment' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -42,7 +42,7 @@ final class Php71 extends AbstractRuleSet
         'doctrine_annotation_spaces' => false,
         'ereg_to_preg' => true,
         'function_typehint_space' => true,
-        'function_to_constant' => false,
+        'function_to_constant' => true,
         'general_phpdoc_annotation_remove' => false,
         'hash_to_slash_comment' => true,
         'header_comment' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -54,7 +54,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,
-            'function_to_constant' => false,
+            'function_to_constant' => true,
             'general_phpdoc_annotation_remove' => false,
             'hash_to_slash_comment' => true,
             'header_comment' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -54,7 +54,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,
-            'function_to_constant' => false,
+            'function_to_constant' => true,
             'general_phpdoc_annotation_remove' => false,
             'hash_to_slash_comment' => true,
             'header_comment' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -54,7 +54,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'doctrine_annotation_spaces' => false,
             'ereg_to_preg' => true,
             'function_typehint_space' => true,
-            'function_to_constant' => false,
+            'function_to_constant' => true,
             'general_phpdoc_annotation_remove' => false,
             'hash_to_slash_comment' => true,
             'header_comment' => false,


### PR DESCRIPTION
This PR

* [x] enables the `function_to_constant` fixer

Follows #15.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

> **function_to_constant** [`@Symfony:risky`]
>
>Replace core functions calls returning constants with the constants.
>
>*Risky rule*: risky when any of the configured functions to replace are overridden.