### PR TITLE
Enhancement: Enable magic_constant_casing fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -53,7 +53,7 @@ final class Php56 extends AbstractRuleSet
         ],
         'linebreak_after_opening_tag' => true,
         'lowercase_cast' => true,
-        'magic_constant_casing' => false,
+        'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -53,7 +53,7 @@ final class Php70 extends AbstractRuleSet
         ],
         'linebreak_after_opening_tag' => true,
         'lowercase_cast' => true,
-        'magic_constant_casing' => false,
+        'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -53,7 +53,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'linebreak_after_opening_tag' => true,
         'lowercase_cast' => true,
-        'magic_constant_casing' => false,
+        'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -65,7 +65,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             ],
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
-            'magic_constant_casing' => false,
+            'magic_constant_casing' => true,
             'mb_str_functions' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -65,7 +65,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             ],
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
-            'magic_constant_casing' => false,
+            'magic_constant_casing' => true,
             'mb_str_functions' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -65,7 +65,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             ],
             'linebreak_after_opening_tag' => true,
             'lowercase_cast' => true,
-            'magic_constant_casing' => false,
+            'magic_constant_casing' => true,
             'mb_str_functions' => true,
             'method_separation' => true,
             'modernize_types_casting' => true,


### PR DESCRIPTION
This PR

* [x] enables the `magic_constant_casing` fixer

Follows #15.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**magic_constant_casing** [`@Symfony`]
>
>Magic constants should be referred to using the correct casing.