### PR TITLE
Enhancement: Enable non_printable_character fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -100,7 +100,7 @@ final class Php56 extends AbstractRuleSet
         'no_useless_return' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
-        'non_printable_character' => false,
+        'non_printable_character' => true,
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -100,7 +100,7 @@ final class Php70 extends AbstractRuleSet
         'no_useless_return' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
-        'non_printable_character' => false,
+        'non_printable_character' => true,
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -100,7 +100,7 @@ final class Php71 extends AbstractRuleSet
         'no_useless_return' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
-        'non_printable_character' => false,
+        'non_printable_character' => true,
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -112,7 +112,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false,
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -112,7 +112,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false,
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -112,7 +112,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => true,
             'no_whitespace_in_blank_line' => true,
-            'non_printable_character' => false,
+            'non_printable_character' => true,
             'normalize_index_brace' => true,
             'not_operator_with_space' => false,
             'not_operator_with_successor_space' => false,


### PR DESCRIPTION
This PR

* [x] enables the `non_printable_character` fixer

Follows #15.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>**non_printable_character** [`@Symfony:risky`]
>
>Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.
>
>*Risky rule*: risky when strings contain intended invisible characters.