### PR TITLE
Enhancement: Enable list_syntax fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -52,7 +52,9 @@ final class Php71 extends AbstractRuleSet
             'use_yoda_style' => true,
         ],
         'linebreak_after_opening_tag' => true,
-        'list_syntax' => false,
+        'list_syntax' => [
+            'syntax' => 'short',
+        ],
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -64,7 +64,9 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'use_yoda_style' => true,
             ],
             'linebreak_after_opening_tag' => true,
-            'list_syntax' => false,
+            'list_syntax' => [
+                'syntax' => 'short',
+            ],
             'lowercase_cast' => true,
             'magic_constant_casing' => true,
             'mb_str_functions' => true,


### PR DESCRIPTION
This PR

* [x] enables the `list_syntax` fixer

Follows #22.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage:

>list_syntax
>
>List (`array` destructuring) assignment should be declared using the configured syntax. Requires PHP >>= 7.1.
>
>Configuration options:
>
>`syntax` (`'long'`, `'short'`): whether to use the `long` or `short` `list` syntax; defaults to `'long'`
