### PR TITLE
Enhancement: Enable align_multi_line_comment fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -17,7 +17,9 @@ final class Php56 extends AbstractRuleSet
 
     protected $rules = [
         '@PSR2' => true,
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => [
+            'comment_type' => 'all_multiline',
+        ],
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -17,7 +17,9 @@ final class Php70 extends AbstractRuleSet
 
     protected $rules = [
         '@PSR2' => true,
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => [
+            'comment_type' => 'all_multiline',
+        ],
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -17,7 +17,9 @@ final class Php71 extends AbstractRuleSet
 
     protected $rules = [
         '@PSR2' => true,
-        'align_multiline_comment' => false,
+        'align_multiline_comment' => [
+            'comment_type' => 'all_multiline',
+        ],
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -29,7 +29,9 @@ final class Php56Test extends AbstractRuleSetTestCase
     {
         return [
             '@PSR2' => true,
-            'align_multiline_comment' => false,
+            'align_multiline_comment' => [
+                'comment_type' => 'all_multiline',
+            ],
             'array_syntax' => [
                 'syntax' => 'short',
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -29,7 +29,9 @@ final class Php70Test extends AbstractRuleSetTestCase
     {
         return [
             '@PSR2' => true,
-            'align_multiline_comment' => false,
+            'align_multiline_comment' => [
+                'comment_type' => 'all_multiline',
+            ],
             'array_syntax' => [
                 'syntax' => 'short',
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -29,7 +29,9 @@ final class Php71Test extends AbstractRuleSetTestCase
     {
         return [
             '@PSR2' => true,
-            'align_multiline_comment' => false,
+            'align_multiline_comment' => [
+                'comment_type' => 'all_multiline',
+            ],
             'array_syntax' => [
                 'syntax' => 'short',
             ],


### PR DESCRIPTION
This PR

* [x] enables the `align_multi_line_comment` fixer

Follows #26.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.4.0#usage:

>**align_multiline_comment**
>
>Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.