### PR TITLE
Fix: Use blank_line_before_statement instead of deprecated blank_line_before_return fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -28,8 +28,12 @@ final class Php56 extends AbstractRuleSet
             'align_equals' => false,
         ],
         'blank_line_after_opening_tag' => true,
-        'blank_line_before_return' => true,
-        'blank_line_before_statement' => false,
+        'blank_line_before_return' => false,
+        'blank_line_before_statement' => [
+            'statements' => [
+                'return',
+            ],
+        ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -28,8 +28,12 @@ final class Php70 extends AbstractRuleSet
             'align_equals' => false,
         ],
         'blank_line_after_opening_tag' => true,
-        'blank_line_before_return' => true,
-        'blank_line_before_statement' => false,
+        'blank_line_before_return' => false,
+        'blank_line_before_statement' => [
+            'statements' => [
+                'return',
+            ],
+        ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -28,8 +28,12 @@ final class Php71 extends AbstractRuleSet
             'align_equals' => false,
         ],
         'blank_line_after_opening_tag' => true,
-        'blank_line_before_return' => true,
-        'blank_line_before_statement' => false,
+        'blank_line_before_return' => false,
+        'blank_line_before_statement' => [
+            'statements' => [
+                'return',
+            ],
+        ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -40,8 +40,12 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'align_equals' => false,
             ],
             'blank_line_after_opening_tag' => true,
-            'blank_line_before_return' => true,
-            'blank_line_before_statement' => false,
+            'blank_line_before_return' => false,
+            'blank_line_before_statement' => [
+                'statements' => [
+                    'return',
+                ],
+            ],
             'cast_spaces' => true,
             'class_keyword_remove' => false,
             'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -40,8 +40,12 @@ final class Php70Test extends AbstractRuleSetTestCase
                 'align_equals' => false,
             ],
             'blank_line_after_opening_tag' => true,
-            'blank_line_before_return' => true,
-            'blank_line_before_statement' => false,
+            'blank_line_before_return' => false,
+            'blank_line_before_statement' => [
+                'statements' => [
+                    'return',
+                ],
+            ],
             'cast_spaces' => true,
             'class_keyword_remove' => false,
             'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -40,8 +40,12 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'align_equals' => false,
             ],
             'blank_line_after_opening_tag' => true,
-            'blank_line_before_return' => true,
-            'blank_line_before_statement' => false,
+            'blank_line_before_return' => false,
+            'blank_line_before_statement' => [
+                'statements' => [
+                    'return',
+                ],
+            ],
             'cast_spaces' => true,
             'class_keyword_remove' => false,
             'combine_consecutive_unsets' => true,


### PR DESCRIPTION
This PR

* [x] uses the newly added `blank_line_before_statement` fixer instead of the deprecated `blank_line_before_return` fixer

Follows #26.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.4.0#usage

>**blank_line_before_statement** [`@Symfony`]
>
>An empty line feed must precede any configured statement.