### PR TITLE
Enhancement: Enable doctrine_annotation_array_assignment fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -46,7 +46,7 @@ final class Php56 extends AbstractRuleSet
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],
-        'doctrine_annotation_array_assignment' => false,
+        'doctrine_annotation_array_assignment' => true,
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -46,7 +46,7 @@ final class Php70 extends AbstractRuleSet
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],
-        'doctrine_annotation_array_assignment' => false,
+        'doctrine_annotation_array_assignment' => true,
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -46,7 +46,7 @@ final class Php71 extends AbstractRuleSet
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],
-        'doctrine_annotation_array_assignment' => false,
+        'doctrine_annotation_array_assignment' => true,
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -58,7 +58,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'doctrine_annotation_braces' => [
                 'syntax' => 'without_braces',
             ],
-            'doctrine_annotation_array_assignment' => false,
+            'doctrine_annotation_array_assignment' => true,
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -58,7 +58,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'doctrine_annotation_braces' => [
                 'syntax' => 'without_braces',
             ],
-            'doctrine_annotation_array_assignment' => false,
+            'doctrine_annotation_array_assignment' => true,
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -58,7 +58,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'doctrine_annotation_braces' => [
                 'syntax' => 'without_braces',
             ],
-            'doctrine_annotation_array_assignment' => false,
+            'doctrine_annotation_array_assignment' => true,
             'doctrine_annotation_indentation' => true,
             'doctrine_annotation_spaces' => true,
             'ereg_to_preg' => true,


### PR DESCRIPTION
This PR

* [x] enables the `doctrine_annotation_array_assignment` fixer

Follows #26.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.4.0#usage

>**doctrine_annotation_array_assignment**
>
>Doctrine annotations must use configured operator for assignment in arrays.
