### PR TITLE
Enhancement: Enable no_null_property_initialization fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -96,7 +96,7 @@ final class Php56 extends AbstractRuleSet
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
         'no_multiline_whitespace_before_semicolons' => true,
-        'no_null_property_initialization' => false,
+        'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_short_echo_tag' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -96,7 +96,7 @@ final class Php70 extends AbstractRuleSet
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
         'no_multiline_whitespace_before_semicolons' => true,
-        'no_null_property_initialization' => false,
+        'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_short_echo_tag' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -98,7 +98,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
         'no_multiline_whitespace_before_semicolons' => true,
-        'no_null_property_initialization' => false,
+        'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_short_echo_tag' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -108,7 +108,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             ],
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_multiline_whitespace_before_semicolons' => true,
-            'no_null_property_initialization' => false,
+            'no_null_property_initialization' => true,
             'no_php4_constructor' => false,
             'no_short_bool_cast' => true,
             'no_short_echo_tag' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -108,7 +108,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             ],
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_multiline_whitespace_before_semicolons' => true,
-            'no_null_property_initialization' => false,
+            'no_null_property_initialization' => true,
             'no_php4_constructor' => false,
             'no_short_bool_cast' => true,
             'no_short_echo_tag' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -110,7 +110,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             ],
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_multiline_whitespace_before_semicolons' => true,
-            'no_null_property_initialization' => false,
+            'no_null_property_initialization' => true,
             'no_php4_constructor' => false,
             'no_short_bool_cast' => true,
             'no_short_echo_tag' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_null_property_initialization` fixer

Follows #26.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.4.0#usage:

>**no_null_property_initialization**
>
>Properties MUST not be explicitly initialized with `null`.