### PR TITLE
Enhancement: Enable phpdoc_types_order fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -146,7 +146,10 @@ final class Php56 extends AbstractRuleSet
         'phpdoc_to_comment' => false,
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
-        'phpdoc_types_order' => false,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -146,7 +146,10 @@ final class Php70 extends AbstractRuleSet
         'phpdoc_to_comment' => false,
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
-        'phpdoc_types_order' => false,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -148,7 +148,10 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_to_comment' => false,
         'phpdoc_trim' => true,
         'phpdoc_types' => true,
-        'phpdoc_types_order' => false,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => true,

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -112,7 +112,7 @@ final class FactoryTest extends Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Config\RuleSet
+     * @return Config\RuleSet|\PHPUnit_Framework_MockObject_MockObject
      */
     private function createRuleSetMock()
     {

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -158,7 +158,10 @@ final class Php56Test extends AbstractRuleSetTestCase
             'phpdoc_to_comment' => false,
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
-            'phpdoc_types_order' => false,
+            'phpdoc_types_order' => [
+                'null_adjustment' => 'always_first',
+                'sort_algorithm' => 'alpha',
+            ],
             'phpdoc_var_without_name' => true,
             'pow_to_exponentiation' => true,
             'pre_increment' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -158,7 +158,10 @@ final class Php70Test extends AbstractRuleSetTestCase
             'phpdoc_to_comment' => false,
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
-            'phpdoc_types_order' => false,
+            'phpdoc_types_order' => [
+                'null_adjustment' => 'always_first',
+                'sort_algorithm' => 'alpha',
+            ],
             'phpdoc_var_without_name' => true,
             'pow_to_exponentiation' => true,
             'pre_increment' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -160,7 +160,10 @@ final class Php71Test extends AbstractRuleSetTestCase
             'phpdoc_to_comment' => false,
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
-            'phpdoc_types_order' => false,
+            'phpdoc_types_order' => [
+                'null_adjustment' => 'always_first',
+                'sort_algorithm' => 'alpha',
+            ],
             'phpdoc_var_without_name' => true,
             'pow_to_exponentiation' => true,
             'pre_increment' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_types_order` fixer
* [x] runs `make cs`

Follows #26.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.4.0#usage:

>**phpdoc_types_order**
>
>Sorts PHPDoc types.
