### PR TITLE
Enhancement: Enable no_superfluous_elseif fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -117,7 +117,7 @@ final class Php56 extends AbstractRuleSet
         'no_short_echo_tag' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
-        'no_superfluous_elseif' => false,
+        'no_superfluous_elseif' => true,
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -117,7 +117,7 @@ final class Php70 extends AbstractRuleSet
         'no_short_echo_tag' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
-        'no_superfluous_elseif' => false,
+        'no_superfluous_elseif' => true,
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -119,7 +119,7 @@ final class Php71 extends AbstractRuleSet
         'no_short_echo_tag' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
-        'no_superfluous_elseif' => false,
+        'no_superfluous_elseif' => true,
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -129,7 +129,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'no_short_echo_tag' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
-            'no_superfluous_elseif' => false,
+            'no_superfluous_elseif' => true,
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -129,7 +129,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'no_short_echo_tag' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
-            'no_superfluous_elseif' => false,
+            'no_superfluous_elseif' => true,
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -131,7 +131,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'no_short_echo_tag' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
-            'no_superfluous_elseif' => false,
+            'no_superfluous_elseif' => true,
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_superfluous_elseif` fixer

Follows #35.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.5.0#usage

>**no_superfluous_elseif**
>
>Replaces superfluous `elseif` with `if`.