### PR TITLE
Enhancement: Enable no_unneeded_curly_braces fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -121,7 +121,7 @@ final class Php56 extends AbstractRuleSet
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
-        'no_unneeded_curly_braces' => false,
+        'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => false,
         'no_unreachable_default_argument_value' => true,
         'no_unused_imports' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -121,7 +121,7 @@ final class Php70 extends AbstractRuleSet
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
-        'no_unneeded_curly_braces' => false,
+        'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => false,
         'no_unreachable_default_argument_value' => true,
         'no_unused_imports' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -123,7 +123,7 @@ final class Php71 extends AbstractRuleSet
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,
-        'no_unneeded_curly_braces' => false,
+        'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => false,
         'no_unreachable_default_argument_value' => true,
         'no_unused_imports' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -133,7 +133,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,
-            'no_unneeded_curly_braces' => false,
+            'no_unneeded_curly_braces' => true,
             'no_unneeded_final_method' => false,
             'no_unreachable_default_argument_value' => true,
             'no_unused_imports' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -133,7 +133,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,
-            'no_unneeded_curly_braces' => false,
+            'no_unneeded_curly_braces' => true,
             'no_unneeded_final_method' => false,
             'no_unreachable_default_argument_value' => true,
             'no_unused_imports' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -135,7 +135,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,
-            'no_unneeded_curly_braces' => false,
+            'no_unneeded_curly_braces' => true,
             'no_unneeded_final_method' => false,
             'no_unreachable_default_argument_value' => true,
             'no_unused_imports' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_unneeded_curly_braces` fixer

Follows #35.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.5.0#usage:

>**no_unneeded_curly_braces**
>
>Removes unneeded curly braces that are superfluous and aren't part of a control structure's body.