### PR TITLE
Enhancement: Configure method_argument_space fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -80,6 +80,10 @@ final class Php56 extends AbstractRuleSet
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
+        'method_argument_space' => [
+            'ensure_fully_multiline' => true,
+            'keep_multiple_spaces_after_comma' => false,
+        ],
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -80,6 +80,10 @@ final class Php70 extends AbstractRuleSet
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
+        'method_argument_space' => [
+            'ensure_fully_multiline' => true,
+            'keep_multiple_spaces_after_comma' => false,
+        ],
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -82,6 +82,10 @@ final class Php71 extends AbstractRuleSet
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
+        'method_argument_space' => [
+            'ensure_fully_multiline' => true,
+            'keep_multiple_spaces_after_comma' => false,
+        ],
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -80,6 +80,10 @@ final class Php56Test extends AbstractRuleSetTestCase
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
+        'method_argument_space' => [
+            'ensure_fully_multiline' => true,
+            'keep_multiple_spaces_after_comma' => false,
+        ],
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -80,6 +80,10 @@ final class Php70Test extends AbstractRuleSetTestCase
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
+        'method_argument_space' => [
+            'ensure_fully_multiline' => true,
+            'keep_multiple_spaces_after_comma' => false,
+        ],
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -82,6 +82,10 @@ final class Php71Test extends AbstractRuleSetTestCase
         'lowercase_cast' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
+        'method_argument_space' => [
+            'ensure_fully_multiline' => true,
+            'keep_multiple_spaces_after_comma' => false,
+        ],
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,


### PR DESCRIPTION
This PR

* [x] configures the `method_argument_space` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.5.0#usage:

>**method_argument_space** [`@PSR2`, `@Symfony`]
>
>In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma. Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.
>
>Configuration options:
>
>- `ensure_fully_multiline` (`bool`): ensure every argument of a multiline argument list is on its own line; defaults to false
>- `keep_multiple_spaces_after_comma` (`bool`): whether keep multiple spaces after comma; defaults to false
