### PR TITLE
Fix: Add coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: composer cs it test
+.PHONY: composer coverage cs it test
 
 it: cs test
 
@@ -7,6 +7,9 @@ composer:
 	composer self-update
 	composer validate
 	composer update
+
+coverage: composer
+	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-text
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff


### PR DESCRIPTION
This PR

* [x] adds a `coverage` target to `Makefile`