### PR TITLE
Enhancement: Enable combine_consecutive_issets fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -51,7 +51,7 @@ final class Php56 extends AbstractRuleSet
         ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
-        'combine_consecutive_issets' => false,
+        'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -51,7 +51,7 @@ final class Php70 extends AbstractRuleSet
         ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
-        'combine_consecutive_issets' => false,
+        'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -51,7 +51,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
-        'combine_consecutive_issets' => false,
+        'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -51,7 +51,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
-        'combine_consecutive_issets' => false,
+        'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -51,7 +51,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
-        'combine_consecutive_issets' => false,
+        'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -51,7 +51,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'cast_spaces' => true,
         'class_keyword_remove' => false,
-        'combine_consecutive_issets' => false,
+        'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'concat_space' => [
             'spacing' => 'one',


### PR DESCRIPTION
This PR

* [x] enables the `combine_consecutive_issets` fixer

Follows #45.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.6.0#usage:

>**no_homoglyph_names**
>
>Replace accidental usage of homoglyphs (non ascii characters) in names.
>
>Risky rule: renames classes and cannot rename the files. You might have string references to renamed code (`$$name`).