### PR TITLE
Enhancement: Enable no_homoglyph_names fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -109,7 +109,7 @@ final class Php56 extends AbstractRuleSet
             'use',
             'useTrait',
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -109,7 +109,7 @@ final class Php70 extends AbstractRuleSet
             'use',
             'useTrait',
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -111,7 +111,7 @@ final class Php71 extends AbstractRuleSet
             'use',
             'useTrait',
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -109,7 +109,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'use',
             'useTrait',
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -109,7 +109,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'use',
             'useTrait',
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -111,7 +111,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'use',
             'useTrait',
         ],
-        'no_homoglyph_names' => false,
+        'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_mixed_echo_print' => [


### PR DESCRIPTION
This PR

* [x] enables the `no_homoglyph_names` fixer

Follows #45.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.6.0#usage:

>**no_homoglyph_names**
>
>Replace accidental usage of homoglyphs (non ascii characters) in names.
>
>Risky rule: renames classes and cannot rename the files. You might have string references to renamed code (`$$name`).