### PR TITLE
Enhancement: Enable yoda_style fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -73,9 +73,7 @@ final class Php56 extends AbstractRuleSet
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
         'include' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
         'lowercase_cast' => true,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -205,7 +205,11 @@ final class Php56 extends AbstractRuleSet
         ],
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
-        'yoda_style' => false,
+        'yoda_style' => [
+            'equal' => true,
+            'identical' => true,
+            'less_and_greater' => true,
+        ],
     ];
 
     protected $targetPhpVersion = 50600;

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -73,9 +73,7 @@ final class Php70 extends AbstractRuleSet
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
         'include' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
         'lowercase_cast' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -205,7 +205,11 @@ final class Php70 extends AbstractRuleSet
         ],
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
-        'yoda_style' => false,
+        'yoda_style' => [
+            'equal' => true,
+            'identical' => true,
+            'less_and_greater' => true,
+        ],
     ];
 
     protected $targetPhpVersion = 70000;

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -208,7 +208,11 @@ final class Php71 extends AbstractRuleSet
         ],
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
-        'yoda_style' => false,
+        'yoda_style' => [
+            'equal' => true,
+            'identical' => true,
+            'less_and_greater' => true,
+        ],
     ];
 
     protected $targetPhpVersion = 70100;

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -73,9 +73,7 @@ final class Php71 extends AbstractRuleSet
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
         'include' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [
             'syntax' => 'short',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -73,9 +73,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
         'include' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
         'lowercase_cast' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -205,7 +205,11 @@ final class Php56Test extends AbstractRuleSetTestCase
         ],
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
-        'yoda_style' => false,
+        'yoda_style' => [
+            'equal' => true,
+            'identical' => true,
+            'less_and_greater' => true,
+        ],
     ];
 
     protected $targetPhpVersion = 50600;

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -73,9 +73,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
         'include' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
         'lowercase_cast' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -205,7 +205,11 @@ final class Php70Test extends AbstractRuleSetTestCase
         ],
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
-        'yoda_style' => false,
+        'yoda_style' => [
+            'equal' => true,
+            'identical' => true,
+            'less_and_greater' => true,
+        ],
     ];
 
     protected $targetPhpVersion = 70000;

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -208,7 +208,11 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
-        'yoda_style' => false,
+        'yoda_style' => [
+            'equal' => true,
+            'identical' => true,
+            'less_and_greater' => true,
+        ],
     ];
 
     protected $targetPhpVersion = 70100;

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -73,9 +73,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
         'include' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [
             'syntax' => 'short',


### PR DESCRIPTION
This PR

* [x] enables the `yoda_style` fixer
* [x] removes corresponding configuration for `is_null` fixer

Follows #45.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.6.0#usage:

>**yoda_style** [`@Symfony`]
>
>Write conditions in Yoda style or not based on configuration.
>
>Configuration options:
>
>* `equal` (`bool`, `null`): change equal (`==`, `!=`) statements; defaults to `true`
>* `identical` (`bool`, `null`): change identical (`===`, `!==`) statements; defaults to `true`
>* `less_and_greater` (`bool`, `null`): change less and greater than (`<`, `<=`, `>`, `>=`) statements; defaults to `null`
