### PR TITLE
Fix: Configure blank_line_before_statement fixer to include yield

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -47,6 +47,7 @@ final class Php56 extends AbstractRuleSet
                 'throw',
                 'try',
                 'while',
+                'yield',
             ],
         ],
         'cast_spaces' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -47,6 +47,7 @@ final class Php70 extends AbstractRuleSet
                 'throw',
                 'try',
                 'while',
+                'yield',
             ],
         ],
         'cast_spaces' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -47,6 +47,7 @@ final class Php71 extends AbstractRuleSet
                 'throw',
                 'try',
                 'while',
+                'yield',
             ],
         ],
         'cast_spaces' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -47,6 +47,7 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'throw',
                 'try',
                 'while',
+                'yield',
             ],
         ],
         'cast_spaces' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -47,6 +47,7 @@ final class Php70Test extends AbstractRuleSetTestCase
                 'throw',
                 'try',
                 'while',
+                'yield',
             ],
         ],
         'cast_spaces' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -47,6 +47,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'throw',
                 'try',
                 'while',
+                'yield',
             ],
         ],
         'cast_spaces' => true,


### PR DESCRIPTION
This PR

* [x] configures the `blank_line_before_statement` fixer to include `yield`

Follows #32.
