### PR TITLE
Fix: Configure binary_operator_spaces fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -24,8 +24,7 @@ final class Php56 extends AbstractRuleSet
             'syntax' => 'short',
         ],
         'binary_operator_spaces' => [
-            'align_double_arrow' => false,
-            'align_equals' => false,
+            'default' => 'single_space',
         ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_return' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -24,8 +24,7 @@ final class Php70 extends AbstractRuleSet
             'syntax' => 'short',
         ],
         'binary_operator_spaces' => [
-            'align_double_arrow' => false,
-            'align_equals' => false,
+            'default' => 'single_space',
         ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_return' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -24,8 +24,7 @@ final class Php71 extends AbstractRuleSet
             'syntax' => 'short',
         ],
         'binary_operator_spaces' => [
-            'align_double_arrow' => false,
-            'align_equals' => false,
+            'default' => 'single_space',
         ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_return' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -24,8 +24,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'syntax' => 'short',
         ],
         'binary_operator_spaces' => [
-            'align_double_arrow' => false,
-            'align_equals' => false,
+            'default' => 'single_space',
         ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_return' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -24,8 +24,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'syntax' => 'short',
         ],
         'binary_operator_spaces' => [
-            'align_double_arrow' => false,
-            'align_equals' => false,
+            'default' => 'single_space',
         ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_return' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -24,8 +24,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'syntax' => 'short',
         ],
         'binary_operator_spaces' => [
-            'align_double_arrow' => false,
-            'align_equals' => false,
+            'default' => 'single_space',
         ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_return' => false,


### PR DESCRIPTION
This PR

* [x] configures the `binary_operator_spaces` fixer

Follows #57.

💁‍♂️ As seen in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2573, the `BinaryOperatorSpacesFixer` has been overhauled, and configuration options have been deprecated.