### PR TITLE
Fix: Do not optimize autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         }
     ],
     "config": {
-        "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true
     },


### PR DESCRIPTION
This PR

* [x] reverts the `composer` configuration to optimize the autoloader  in #55 
