### PR TITLE
Enhancement: Enable compact_nullable_typehint fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -53,7 +53,7 @@ final class Php71 extends AbstractRuleSet
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'compact_nullable_typehint' => false,
+        'compact_nullable_typehint' => true,
         'concat_space' => [
             'spacing' => 'one',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -53,7 +53,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'compact_nullable_typehint' => false,
+        'compact_nullable_typehint' => true,
         'concat_space' => [
             'spacing' => 'one',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `compact_nullable_typehint` fixer

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**compact_nullable_typehint**
>
>Remove extra spaces in a nullable typehint.
