### PR TITLE
Enhancement: Enable php_unit_expectation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -146,7 +146,9 @@ final class Php56 extends AbstractRuleSet
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_expectation' => false,
+        'php_unit_expectation' => [
+            'target' => 'newest',
+        ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => false,
         'php_unit_namespaced' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -146,7 +146,9 @@ final class Php70 extends AbstractRuleSet
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_expectation' => false,
+        'php_unit_expectation' => [
+            'target' => 'newest',
+        ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => false,
         'php_unit_namespaced' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -148,7 +148,9 @@ final class Php71 extends AbstractRuleSet
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_expectation' => false,
+        'php_unit_expectation' => [
+            'target' => 'newest',
+        ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => false,
         'php_unit_namespaced' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -146,7 +146,9 @@ final class Php56Test extends AbstractRuleSetTestCase
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_expectation' => false,
+        'php_unit_expectation' => [
+            'target' => 'newest',
+        ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => false,
         'php_unit_namespaced' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -146,7 +146,9 @@ final class Php70Test extends AbstractRuleSetTestCase
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_expectation' => false,
+        'php_unit_expectation' => [
+            'target' => 'newest',
+        ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => false,
         'php_unit_namespaced' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -148,7 +148,9 @@ final class Php71Test extends AbstractRuleSetTestCase
         'ordered_imports' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_expectation' => false,
+        'php_unit_expectation' => [
+            'target' => 'newest',
+        ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => false,
         'php_unit_namespaced' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_expectation` fixer

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
>
>Usages of `->setExpectedException*` methods MUST be replaced by `->expectException*` methods.
>
>*Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.*
>
>Configuration options:
>
>* `target` (`'5.2'`, `'5.6'`, `'newest'`): target version of PHPUnit; defaults to `'newest'`