### PR TITLE
Enhancement: Enable php_unit_mock fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -148,7 +148,7 @@ final class Php56 extends AbstractRuleSet
         'php_unit_dedicate_assert' => true,
         'php_unit_expectation' => false,
         'php_unit_fqcn_annotation' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -148,7 +148,7 @@ final class Php70 extends AbstractRuleSet
         'php_unit_dedicate_assert' => true,
         'php_unit_expectation' => false,
         'php_unit_fqcn_annotation' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -150,7 +150,7 @@ final class Php71 extends AbstractRuleSet
         'php_unit_dedicate_assert' => true,
         'php_unit_expectation' => false,
         'php_unit_fqcn_annotation' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -148,7 +148,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'php_unit_dedicate_assert' => true,
         'php_unit_expectation' => false,
         'php_unit_fqcn_annotation' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -148,7 +148,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'php_unit_dedicate_assert' => true,
         'php_unit_expectation' => false,
         'php_unit_fqcn_annotation' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -150,7 +150,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'php_unit_dedicate_assert' => true,
         'php_unit_expectation' => false,
         'php_unit_fqcn_annotation' => true,
-        'php_unit_mock' => false,
+        'php_unit_mock' => true,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_mock` fixer

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**php_unit_mock** [@PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
>
>Usages of `->getMock` and `->getMockWithoutInvokingTheOriginalConstructor` methods MUST be replaced by `->createMock` method.
>
>*Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities*.