### PR TITLE
Enhancement: Enable php_unit_namespaced fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -151,7 +151,9 @@ final class Php56 extends AbstractRuleSet
         ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => [
+            'target' => '5.7',
+        ],
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -151,7 +151,9 @@ final class Php70 extends AbstractRuleSet
         ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => [
+            'target' => 'newest',
+        ],
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -153,7 +153,9 @@ final class Php71 extends AbstractRuleSet
         ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => [
+            'target' => 'newest',
+        ],
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -151,7 +151,9 @@ final class Php56Test extends AbstractRuleSetTestCase
         ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => [
+            'target' => '5.7',
+        ],
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -151,7 +151,9 @@ final class Php70Test extends AbstractRuleSetTestCase
         ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => [
+            'target' => 'newest',
+        ],
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -153,7 +153,9 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'php_unit_fqcn_annotation' => true,
         'php_unit_mock' => true,
-        'php_unit_namespaced' => false,
+        'php_unit_namespaced' => [
+            'target' => 'newest',
+        ],
         'php_unit_no_expectation_annotation' => false,
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_namespaced` fixer

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**php_unit_namespaced** [@PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
>
>PHPUnit classes MUST be used in namespaced version, eg `\PHPUnit\Framework\TestCase` instead of `\PHPUnit_Framework_TestCase`.
>
>*Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities*.
>
>Configuration options:
>
> * `target` (`'4.8'`, `'5.7'`, `'6.0'`, `'newest'`): target version of PHPUnit; defaults to `'newest'`
