### PR TITLE
Enhancement: Enable php_unit_no_expectation_annotation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -154,7 +154,10 @@ final class Php56 extends AbstractRuleSet
         'php_unit_namespaced' => [
             'target' => '5.7',
         ],
-        'php_unit_no_expectation_annotation' => false,
+        'php_unit_no_expectation_annotation' => [
+            'target' => 'newest',
+            'use_class_const' => true,
+        ],
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -154,7 +154,10 @@ final class Php70 extends AbstractRuleSet
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],
-        'php_unit_no_expectation_annotation' => false,
+        'php_unit_no_expectation_annotation' => [
+            'target' => 'newest',
+            'use_class_const' => true,
+        ],
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -156,7 +156,10 @@ final class Php71 extends AbstractRuleSet
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],
-        'php_unit_no_expectation_annotation' => false,
+        'php_unit_no_expectation_annotation' => [
+            'target' => 'newest',
+            'use_class_const' => true,
+        ],
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -154,7 +154,10 @@ final class Php56Test extends AbstractRuleSetTestCase
         'php_unit_namespaced' => [
             'target' => '5.7',
         ],
-        'php_unit_no_expectation_annotation' => false,
+        'php_unit_no_expectation_annotation' => [
+            'target' => 'newest',
+            'use_class_const' => true,
+        ],
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -154,7 +154,10 @@ final class Php70Test extends AbstractRuleSetTestCase
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],
-        'php_unit_no_expectation_annotation' => false,
+        'php_unit_no_expectation_annotation' => [
+            'target' => 'newest',
+            'use_class_const' => true,
+        ],
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -156,7 +156,10 @@ final class Php71Test extends AbstractRuleSetTestCase
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],
-        'php_unit_no_expectation_annotation' => false,
+        'php_unit_no_expectation_annotation' => [
+            'target' => 'newest',
+            'use_class_const' => true,
+        ],
         'php_unit_strict' => false,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_no_expectation_annotation` fixer

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.8.0#usage:

>**php_unit_no_expectation_annotation** [@PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
>
>Usages of `@expectedException*` annotations MUST be replaced by `->setExpectedException*` methods.
>
>*Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.*
>
>Configuration options:
>
>* `target` (`'3.2'`, `'4.3'`, `'newest'`): target version of PHPUnit; defaults to `'newest'`
>* `use_class_const` (`bool`): use `::class` notation; defaults to `true`