### PR TITLE
Fix: Remove limiting configuration for phpdoc_no_alias fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ Copyright (c) 2017 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@link https://github.com/localheinz/php-cs-fixer-config
+@see https://github.com/localheinz/php-cs-fixer-config
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php56($header));

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config;

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config;

--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\RuleSet;

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\RuleSet;

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -168,9 +168,7 @@ final class Php56 extends AbstractRuleSet
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_alias_tag' => [
-            'type' => 'var',
-        ],
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\RuleSet;

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -168,9 +168,7 @@ final class Php70 extends AbstractRuleSet
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_alias_tag' => [
-            'type' => 'var',
-        ],
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -170,9 +170,7 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_alias_tag' => [
-            'type' => 'var',
-        ],
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\RuleSet;

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit;

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -168,9 +168,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_alias_tag' => [
-            'type' => 'var',
-        ],
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -168,9 +168,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_alias_tag' => [
-            'type' => 'var',
-        ],
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -170,9 +170,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
         'phpdoc_no_access' => true,
-        'phpdoc_no_alias_tag' => [
-            'type' => 'var',
-        ],
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;


### PR DESCRIPTION
This PR

* [x] removes limiting configuration for `phpdoc_no_alias_tag` fixer
* [x] runs `make cs`
* [x] adjusts the header comment in `.php_cs`