### PR TITLE
Enhancement: Enable and configure class_attributes_separation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -50,7 +50,12 @@ final class Php56 extends AbstractRuleSet
             ],
         ],
         'cast_spaces' => true,
-        'class_attributes_separation' => false,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -50,7 +50,12 @@ final class Php70 extends AbstractRuleSet
             ],
         ],
         'cast_spaces' => true,
-        'class_attributes_separation' => false,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -50,7 +50,12 @@ final class Php71 extends AbstractRuleSet
             ],
         ],
         'cast_spaces' => true,
-        'class_attributes_separation' => false,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -50,7 +50,12 @@ final class Php56Test extends AbstractRuleSetTestCase
             ],
         ],
         'cast_spaces' => true,
-        'class_attributes_separation' => false,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -50,7 +50,12 @@ final class Php70Test extends AbstractRuleSetTestCase
             ],
         ],
         'cast_spaces' => true,
-        'class_attributes_separation' => false,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -50,7 +50,12 @@ final class Php71Test extends AbstractRuleSetTestCase
             ],
         ],
         'cast_spaces' => true,
-        'class_attributes_separation' => false,
+        'class_attributes_separation' => [
+            'elements' => [
+                'method',
+                'property',
+            ],
+        ],
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `class_attributes_separation` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**class_attributes_separation** [`@Symfony`]
>
>Class, trait and interface elements must be separated with one blank line.
>
>Configuration options:
>
>* `elements` (`array`): list of classy elements; `'const'`, `'method'`, `'property'`; defaults to `['const', 'method', 'property']`
