### PR TITLE
Enhancement: Enable escape_implicit_backslashes fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -68,7 +68,7 @@ final class Php56 extends AbstractRuleSet
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => false,
         'final_internal_class' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -68,7 +68,7 @@ final class Php70 extends AbstractRuleSet
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => false,
         'final_internal_class' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -68,7 +68,7 @@ final class Php71 extends AbstractRuleSet
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => false,
         'final_internal_class' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -68,7 +68,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => false,
         'final_internal_class' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -68,7 +68,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => false,
         'final_internal_class' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -68,7 +68,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'doctrine_annotation_indentation' => true,
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
-        'escape_implicit_backslashes' => false,
+        'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => false,
         'final_internal_class' => false,


### PR DESCRIPTION
This PR

* [x] enables and configures the `escape_implicit_backslashes` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**escape_implicit_backslashes**
>
>Escape implicit backslashes in strings and heredocs to ease the understanding of which are special chars interpreted by PHP and which not.
>
>Configuration options:
>
>* `double_quoted` (`bool`): whether to fix double-quoted strings; defaults to `true`
>* `heredoc_syntax` (`bool`): whether to fix heredoc syntax; defaults to `true`
>* `single_quoted` (`bool`): whether to fix single-quoted strings; defaults to `false`