### PR TITLE
Enhancement: Enable explicit_indirect_variable fixer

### DIFF
--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -74,7 +74,7 @@ final class Php70 extends AbstractRuleSet
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => false,
         'final_internal_class' => false,
         'function_to_constant' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -74,7 +74,7 @@ final class Php71 extends AbstractRuleSet
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => false,
         'final_internal_class' => false,
         'function_to_constant' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -74,7 +74,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => false,
         'final_internal_class' => false,
         'function_to_constant' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -74,7 +74,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'doctrine_annotation_spaces' => true,
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
-        'explicit_indirect_variable' => false,
+        'explicit_indirect_variable' => true,
         'explicit_string_variable' => false,
         'final_internal_class' => false,
         'function_to_constant' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `explicit_indirect_variable` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**explicit_indirect_variable**
>
>Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.
