### PR TITLE
Enhancement: Enable explicit_string_variable fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -75,7 +75,7 @@ final class Php56 extends AbstractRuleSet
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
-        'explicit_string_variable' => false,
+        'explicit_string_variable' => true,
         'final_internal_class' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -75,7 +75,7 @@ final class Php70 extends AbstractRuleSet
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
-        'explicit_string_variable' => false,
+        'explicit_string_variable' => true,
         'final_internal_class' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -75,7 +75,7 @@ final class Php71 extends AbstractRuleSet
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
-        'explicit_string_variable' => false,
+        'explicit_string_variable' => true,
         'final_internal_class' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -75,7 +75,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
-        'explicit_string_variable' => false,
+        'explicit_string_variable' => true,
         'final_internal_class' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -75,7 +75,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
-        'explicit_string_variable' => false,
+        'explicit_string_variable' => true,
         'final_internal_class' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -75,7 +75,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'ereg_to_preg' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
-        'explicit_string_variable' => false,
+        'explicit_string_variable' => true,
         'final_internal_class' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `explicit_string_variable` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**explicit_string_variable**
>
>Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.