### PR TITLE
Enhancement: Enable final_internal_class fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -76,7 +76,7 @@ final class Php56 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -76,7 +76,7 @@ final class Php70 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -76,7 +76,7 @@ final class Php71 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -76,7 +76,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -76,7 +76,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -76,7 +76,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_internal_class' => false,
+        'final_internal_class' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,


### PR DESCRIPTION
This PR

* [x] enables and configures the `explicit_indirect_variable` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**final_internal_class**
>
>Internal classes should be `final`.
>
>**Risky rule: changing classes to ``final`` might cause code execution to break.**
>
>Configuration options:
>
>* `annotation-black-list` (`array`): class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case in sensitive); defaults to [`'@final'`, `'@Entity'`, `'@ORM'`]
>* `annotation-white-list` (`array`): class level annotations tags that must be set in order to fix the class. (case in sensitive); defaults to [`'@internal'`]