### PR TITLE
Enhancement: Enable method_chaining_indentation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -97,7 +97,7 @@ final class Php56 extends AbstractRuleSet
             'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -97,7 +97,7 @@ final class Php70 extends AbstractRuleSet
             'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -99,7 +99,7 @@ final class Php71 extends AbstractRuleSet
             'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -97,7 +97,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -97,7 +97,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -99,7 +99,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
         ],
-        'method_chaining_indentation' => false,
+        'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
         'native_function_casing' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `method_chaining_indentation` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**method_chaining_indentation**
>
>Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.