### PR TITLE
Enhancement: Enable php_unit_test_annotation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -170,7 +170,7 @@ final class Php56 extends AbstractRuleSet
             'use_class_const' => true,
         ],
         'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -170,7 +170,7 @@ final class Php70 extends AbstractRuleSet
             'use_class_const' => true,
         ],
         'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -172,7 +172,7 @@ final class Php71 extends AbstractRuleSet
             'use_class_const' => true,
         ],
         'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -170,7 +170,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'use_class_const' => true,
         ],
         'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -170,7 +170,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'use_class_const' => true,
         ],
         'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -172,7 +172,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'use_class_const' => true,
         ],
         'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,


### PR DESCRIPTION
This PR

* [x] enables and configures the `php_unit_test_annotation` fixer

Follows #84.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

>**php_unit_test_annotation**
>
>Adds or removes `@test` annotations from tests, following configuration.
>
>*Risky rule: this fixer may change the name of your tests, and could cause incompatibility with abstract classes or interfaces.*
>
>Configuration options:
>
>* `case` (`'camel'`, `'snake'`): whether to camel or snake case when adding the test prefix; defaults to `'camel'`
>* `style` (`'annotation'`, `'prefix'`): whether to use the `@test` annotation or not; defaults to `'prefix'`