### PR TITLE
Fix: Use proper annotation for link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Copyright (c) 2017 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@link https://github.com/localheinz/php-cs-fixer-config
+@see https://github.com/localheinz/php-cs-fixer-config
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php56($header));
@@ -83,7 +83,7 @@ file headers will be added to PHP files, for example:
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @link https://github.com/localheinz/php-cs-fixer-config
+ * @see https://github.com/localheinz/php-cs-fixer-config
  */
 ```
 


### PR DESCRIPTION
This PR

* [x] uses the `@see` annotation instead of `@link`

Follows #83.