### PR TITLE
Fix: Use use_trait instead of deprecated useTrait token

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -121,7 +121,7 @@ final class Php56 extends AbstractRuleSet
                 'square_brace_block',
                 'throw',
                 'use',
-                'useTrait',
+                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -121,7 +121,7 @@ final class Php70 extends AbstractRuleSet
                 'square_brace_block',
                 'throw',
                 'use',
-                'useTrait',
+                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -123,7 +123,7 @@ final class Php71 extends AbstractRuleSet
                 'square_brace_block',
                 'throw',
                 'use',
-                'useTrait',
+                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -121,7 +121,7 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'square_brace_block',
                 'throw',
                 'use',
-                'useTrait',
+                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -121,7 +121,7 @@ final class Php70Test extends AbstractRuleSetTestCase
                 'square_brace_block',
                 'throw',
                 'use',
-                'useTrait',
+                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -123,7 +123,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'square_brace_block',
                 'throw',
                 'use',
-                'useTrait',
+                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,


### PR DESCRIPTION
This PR

* [x] use `use_trait` instead of deprecated `useTrait` token in configuration for `no_extra_consecutive_blank_lines` fixer
  