### PR TITLE
Fix: Use no_extra_blank_lines fixer instead of deprecated no_extra_consecutive_lines

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -115,8 +115,7 @@ final class Php56 extends AbstractRuleSet
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_blank_lines' => false,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',
@@ -133,6 +132,7 @@ final class Php56 extends AbstractRuleSet
                 'use_trait',
             ],
         ],
+        'no_extra_consecutive_blank_lines' => false,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -115,8 +115,7 @@ final class Php70 extends AbstractRuleSet
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_blank_lines' => false,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',
@@ -133,6 +132,7 @@ final class Php70 extends AbstractRuleSet
                 'use_trait',
             ],
         ],
+        'no_extra_consecutive_blank_lines' => false,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -117,8 +117,7 @@ final class Php71 extends AbstractRuleSet
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_blank_lines' => false,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',
@@ -135,6 +134,7 @@ final class Php71 extends AbstractRuleSet
                 'use_trait',
             ],
         ],
+        'no_extra_consecutive_blank_lines' => false,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -115,8 +115,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_blank_lines' => false,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',
@@ -133,6 +132,7 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'use_trait',
             ],
         ],
+        'no_extra_consecutive_blank_lines' => false,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -115,8 +115,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_blank_lines' => false,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',
@@ -133,6 +132,7 @@ final class Php70Test extends AbstractRuleSetTestCase
                 'use_trait',
             ],
         ],
+        'no_extra_consecutive_blank_lines' => false,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -117,8 +117,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
-        'no_extra_blank_lines' => false,
-        'no_extra_consecutive_blank_lines' => [
+        'no_extra_blank_lines' => [
             'tokens' => [
                 'break',
                 'case',
@@ -135,6 +134,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'use_trait',
             ],
         ],
+        'no_extra_consecutive_blank_lines' => false,
         'no_homoglyph_names' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,


### PR DESCRIPTION
This PR

* [x] uses the `no_extra_blank_lines` fixer instead of the `no_extra_consecutive_blank_lines` fixer

Follows #99.

💁‍♂️ The fixer has only been renamed, that is all.