### PR TITLE
Enhancement: Enable backtick_to_shell_exec fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -23,7 +23,7 @@ final class Php56 extends AbstractRuleSet
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'backtick_to_shell_exec' => false,
+        'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -23,7 +23,7 @@ final class Php70 extends AbstractRuleSet
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'backtick_to_shell_exec' => false,
+        'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -23,7 +23,7 @@ final class Php71 extends AbstractRuleSet
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'backtick_to_shell_exec' => false,
+        'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -23,7 +23,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'backtick_to_shell_exec' => false,
+        'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -23,7 +23,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'backtick_to_shell_exec' => false,
+        'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -23,7 +23,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'backtick_to_shell_exec' => false,
+        'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `backtick_to_shell_exec` fixer

Follows #99.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.10.0#usage:

>**backtick_to_shell_exec**
>
>Converts backtick operators to shell_exec calls.