### PR TITLE
Enhancement: Enable multiline_comment_opening_closing fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -101,7 +101,7 @@ final class Php56 extends AbstractRuleSet
         'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -101,7 +101,7 @@ final class Php70 extends AbstractRuleSet
         'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -103,7 +103,7 @@ final class Php71 extends AbstractRuleSet
         'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -101,7 +101,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -101,7 +101,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -103,7 +103,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'method_chaining_indentation' => true,
         'method_separation' => true,
         'modernize_types_casting' => true,
-        'multiline_comment_opening_closing' => false,
+        'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `multiline_comment_opening_closing` fixer

Follows #99.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.10.0#usage:

>**multiline_comment_opening_closing**
>
>DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash.