### PR TITLE
Fix: Normalize composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "localheinz/php-cs-fixer-config",
-    "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
     "type": "library",
+    "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
     "license": "MIT",
     "authors": [
         {
@@ -9,16 +9,16 @@
             "email": "am@localheinz.com"
         }
     ],
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
     "require": {
         "php": "^5.6 || ^7.0",
         "friendsofphp/php-cs-fixer": "~2.10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.25"
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR

* [x] normalizes `composer.json`

💁‍♂️ For reference, see https://github.com/localheinz/composer-normalize.