### PR TITLE
Fix: Indent composer.json with 2 spaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,38 +1,38 @@
 {
-    "name": "localheinz/php-cs-fixer-config",
-    "type": "library",
-    "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
-    "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Andreas Möller",
-            "email": "am@localheinz.com"
-        }
-    ],
-    "require": {
-        "php": "^5.6 || ^7.0",
-        "friendsofphp/php-cs-fixer": "~2.10.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^5.7.25"
-    },
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true
-    },
-    "autoload": {
-        "psr-4": {
-            "Localheinz\\PhpCsFixer\\Config\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Localheinz\\PhpCsFixer\\Config\\Test\\": "test"
-        }
-    },
-    "support": {
-        "issues": "https://github.com/localheinz/php-cs-fixer-config/issues",
-        "source": "https://github.com/localheinz/php-cs-fixer-config"
+  "name": "localheinz/php-cs-fixer-config",
+  "type": "library",
+  "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
+  "homepage": "https://github.com/localheinz/php-cs-fixer-config",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Andreas Möller",
+      "email": "am@localheinz.com"
     }
+  ],
+  "require": {
+    "php": "^5.6 || ^7.0",
+    "friendsofphp/php-cs-fixer": "~2.10.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7.25"
+  },
+  "config": {
+    "preferred-install": "dist",
+    "sort-packages": true
+  },
+  "autoload": {
+    "psr-4": {
+      "Localheinz\\PhpCsFixer\\Config\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Localheinz\\PhpCsFixer\\Config\\Test\\": "test"
+    }
+  },
+  "support": {
+    "issues": "https://github.com/localheinz/php-cs-fixer-config/issues",
+    "source": "https://github.com/localheinz/php-cs-fixer-config"
+  }
 }


### PR DESCRIPTION
This PR

* [x] indents `composer.json` with 2 spaces