### PR TITLE
Enhancement: Configure doctrine_annotation_array_assignment fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -67,7 +67,9 @@ final class Php56 extends AbstractRuleSet
         'declare_equal_normalize' => true,
         'declare_strict_types' => false,
         'dir_constant' => true,
-        'doctrine_annotation_array_assignment' => true,
+        'doctrine_annotation_array_assignment' => [
+            'operator' => ':',
+        ],
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -67,7 +67,9 @@ final class Php70 extends AbstractRuleSet
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
-        'doctrine_annotation_array_assignment' => true,
+        'doctrine_annotation_array_assignment' => [
+            'operator' => ':',
+        ],
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -67,7 +67,9 @@ final class Php71 extends AbstractRuleSet
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
-        'doctrine_annotation_array_assignment' => true,
+        'doctrine_annotation_array_assignment' => [
+            'operator' => ':',
+        ],
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -67,7 +67,9 @@ final class Php56Test extends AbstractRuleSetTestCase
         'declare_equal_normalize' => true,
         'declare_strict_types' => false,
         'dir_constant' => true,
-        'doctrine_annotation_array_assignment' => true,
+        'doctrine_annotation_array_assignment' => [
+            'operator' => ':',
+        ],
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -67,7 +67,9 @@ final class Php70Test extends AbstractRuleSetTestCase
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
-        'doctrine_annotation_array_assignment' => true,
+        'doctrine_annotation_array_assignment' => [
+            'operator' => ':',
+        ],
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -67,7 +67,9 @@ final class Php71Test extends AbstractRuleSetTestCase
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
-        'doctrine_annotation_array_assignment' => true,
+        'doctrine_annotation_array_assignment' => [
+            'operator' => ':',
+        ],
         'doctrine_annotation_braces' => [
             'syntax' => 'without_braces',
         ],


### PR DESCRIPTION
This PR

* [x] configures the `doctrine_annotation_array_assignment` fixer to use `:` as operator instead of `=`

Follows #29.