### PR TITLE
Enhancement: Enable array_indentation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -20,7 +20,7 @@ final class Php56 extends AbstractRuleSet
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
         ],
-        'array_indentation' => false,
+        'array_indentation' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -20,7 +20,7 @@ final class Php70 extends AbstractRuleSet
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
         ],
-        'array_indentation' => false,
+        'array_indentation' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -20,7 +20,7 @@ final class Php71 extends AbstractRuleSet
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
         ],
-        'array_indentation' => false,
+        'array_indentation' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -20,7 +20,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
         ],
-        'array_indentation' => false,
+        'array_indentation' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -20,7 +20,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
         ],
-        'array_indentation' => false,
+        'array_indentation' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -20,7 +20,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
         ],
-        'array_indentation' => false,
+        'array_indentation' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `array_indentation` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

> **array_indentation**
>
>Each element of an array must be indented exactly once.