### PR TITLE
Enhancement: Enable comment_to_phpdoc fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -61,7 +61,7 @@ final class Php56 extends AbstractRuleSet
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'comment_to_phpdoc' => false,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => false,
         'concat_space' => [
             'spacing' => 'one',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -61,7 +61,7 @@ final class Php70 extends AbstractRuleSet
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'comment_to_phpdoc' => false,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => false,
         'concat_space' => [
             'spacing' => 'one',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -61,7 +61,7 @@ final class Php71 extends AbstractRuleSet
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'comment_to_phpdoc' => false,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => [
             'spacing' => 'one',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -61,7 +61,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'comment_to_phpdoc' => false,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => false,
         'concat_space' => [
             'spacing' => 'one',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -61,7 +61,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'comment_to_phpdoc' => false,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => false,
         'concat_space' => [
             'spacing' => 'one',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -61,7 +61,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'comment_to_phpdoc' => false,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => [
             'spacing' => 'one',


### PR DESCRIPTION
This PR

* [x] enables the `comment_to_phpdoc` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**comment_to_phpdoc**
>
>Comments with annotation should be docblock.
>
>*Risky rule: risky as new docblocks might began mean more, e.g. Doctrine's entity might have a new column in database.*
