### PR TITLE
Enhancement: Enable date_time_immutable fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -66,7 +66,7 @@ final class Php56 extends AbstractRuleSet
         'concat_space' => [
             'spacing' => 'one',
         ],
-        'date_time_immutable' => false,
+        'date_time_immutable' => true,
         'declare_equal_normalize' => true,
         'declare_strict_types' => false,
         'dir_constant' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -66,7 +66,7 @@ final class Php70 extends AbstractRuleSet
         'concat_space' => [
             'spacing' => 'one',
         ],
-        'date_time_immutable' => false,
+        'date_time_immutable' => true,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -66,7 +66,7 @@ final class Php71 extends AbstractRuleSet
         'concat_space' => [
             'spacing' => 'one',
         ],
-        'date_time_immutable' => false,
+        'date_time_immutable' => true,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -66,7 +66,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'concat_space' => [
             'spacing' => 'one',
         ],
-        'date_time_immutable' => false,
+        'date_time_immutable' => true,
         'declare_equal_normalize' => true,
         'declare_strict_types' => false,
         'dir_constant' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -66,7 +66,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'concat_space' => [
             'spacing' => 'one',
         ],
-        'date_time_immutable' => false,
+        'date_time_immutable' => true,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -66,7 +66,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'concat_space' => [
             'spacing' => 'one',
         ],
-        'date_time_immutable' => false,
+        'date_time_immutable' => true,
         'declare_equal_normalize' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,


### PR DESCRIPTION
This PR

* [x] enables the `date_time_immutable` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**date_time_immutable**
>
>Class `DateTimeImmutable` should be used instead of `DateTime`.
>
>*Risky rule: risky when the code relies on modifying `DateTime` object or if any of the `date_create*` functions are overridden.*