### PR TITLE
Enhancement: Enable fully_qualified_strict_types fixer

### DIFF
--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -91,7 +91,7 @@ final class Php70 extends AbstractRuleSet
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fully_qualified_strict_types' => false,
+        'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -91,7 +91,7 @@ final class Php71 extends AbstractRuleSet
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fully_qualified_strict_types' => false,
+        'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -91,7 +91,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fully_qualified_strict_types' => false,
+        'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -91,7 +91,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fully_qualified_strict_types' => false,
+        'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
         'general_phpdoc_annotation_remove' => false,


### PR DESCRIPTION
This PR

* [x] enables the `fully_qualified_strict_types` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

> **fully_qualified_strict_types**
>
> Transforms imported FQCN parameters and return types in function arguments to short version.