### PR TITLE
Enhancement: Enable no_alternative_syntax fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -123,7 +123,7 @@ final class Php56 extends AbstractRuleSet
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alternative_syntax' => false,
+        'no_alternative_syntax' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -123,7 +123,7 @@ final class Php70 extends AbstractRuleSet
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alternative_syntax' => false,
+        'no_alternative_syntax' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -125,7 +125,7 @@ final class Php71 extends AbstractRuleSet
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alternative_syntax' => false,
+        'no_alternative_syntax' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -123,7 +123,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alternative_syntax' => false,
+        'no_alternative_syntax' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -123,7 +123,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alternative_syntax' => false,
+        'no_alternative_syntax' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -125,7 +125,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'native_function_invocation' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alternative_syntax' => false,
+        'no_alternative_syntax' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,


### PR DESCRIPTION
This PR

* [x] enables the `no_alternative_syntax` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**no_alternative_syntax**
>
>Replace control structure alternative syntax to use braces.