### PR TITLE
Enhancement: Enable php_unit_ordered_covers fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -195,7 +195,7 @@ final class Php56 extends AbstractRuleSet
             'target' => 'newest',
             'use_class_const' => true,
         ],
-        'php_unit_ordered_covers' => false,
+        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -195,7 +195,7 @@ final class Php70 extends AbstractRuleSet
             'target' => 'newest',
             'use_class_const' => true,
         ],
-        'php_unit_ordered_covers' => false,
+        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -197,7 +197,7 @@ final class Php71 extends AbstractRuleSet
             'target' => 'newest',
             'use_class_const' => true,
         ],
-        'php_unit_ordered_covers' => false,
+        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -195,7 +195,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'target' => 'newest',
             'use_class_const' => true,
         ],
-        'php_unit_ordered_covers' => false,
+        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -195,7 +195,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'target' => 'newest',
             'use_class_const' => true,
         ],
-        'php_unit_ordered_covers' => false,
+        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -197,7 +197,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'target' => 'newest',
             'use_class_const' => true,
         ],
-        'php_unit_ordered_covers' => false,
+        'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_ordered_covers` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**php_unit_ordered_covers**
>
>Order `@covers` annotation of PHPUnit tests.