### PR TITLE
Enhancement: Enable php_unit_set_up_tear_down_visibility fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -196,7 +196,7 @@ final class Php56 extends AbstractRuleSet
             'use_class_const' => true,
         ],
         'php_unit_ordered_covers' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -196,7 +196,7 @@ final class Php70 extends AbstractRuleSet
             'use_class_const' => true,
         ],
         'php_unit_ordered_covers' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -198,7 +198,7 @@ final class Php71 extends AbstractRuleSet
             'use_class_const' => true,
         ],
         'php_unit_ordered_covers' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -196,7 +196,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'use_class_const' => true,
         ],
         'php_unit_ordered_covers' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -196,7 +196,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'use_class_const' => true,
         ],
         'php_unit_ordered_covers' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -198,7 +198,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'use_class_const' => true,
         ],
         'php_unit_ordered_covers' => true,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_set_up_tear_down_visibility` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**php_unit_set_up_tear_down_visibility**
>
>Changes the visibility of the setUp and tearDown functions of phpunit to protected, to match the PHPUnit TestCase.
>
>*Risky rule: this fixer may change functions named setUp or tearDown outside of PHPUnit tests, when a class is wrongly seen as a PHPUnit test.*