### PR TITLE
Enhancement: Enable standardize_increment fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -242,7 +242,7 @@ final class Php56 extends AbstractRuleSet
         'single_line_comment_style' => false,
         'single_quote' => true,
         'space_after_semicolon' => true,
-        'standardize_increment' => false,
+        'standardize_increment' => true,
         'standardize_not_equals' => true,
         'static_lambda' => false,
         'strict_comparison' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -242,7 +242,7 @@ final class Php70 extends AbstractRuleSet
         'single_line_comment_style' => false,
         'single_quote' => true,
         'space_after_semicolon' => true,
-        'standardize_increment' => false,
+        'standardize_increment' => true,
         'standardize_not_equals' => true,
         'static_lambda' => false,
         'strict_comparison' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -244,7 +244,7 @@ final class Php71 extends AbstractRuleSet
         'single_line_comment_style' => false,
         'single_quote' => true,
         'space_after_semicolon' => true,
-        'standardize_increment' => false,
+        'standardize_increment' => true,
         'standardize_not_equals' => true,
         'static_lambda' => false,
         'strict_comparison' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -242,7 +242,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'single_line_comment_style' => false,
         'single_quote' => true,
         'space_after_semicolon' => true,
-        'standardize_increment' => false,
+        'standardize_increment' => true,
         'standardize_not_equals' => true,
         'static_lambda' => false,
         'strict_comparison' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -242,7 +242,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'single_line_comment_style' => false,
         'single_quote' => true,
         'space_after_semicolon' => true,
-        'standardize_increment' => false,
+        'standardize_increment' => true,
         'standardize_not_equals' => true,
         'static_lambda' => false,
         'strict_comparison' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -244,7 +244,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'single_line_comment_style' => false,
         'single_quote' => true,
         'space_after_semicolon' => true,
-        'standardize_increment' => false,
+        'standardize_increment' => true,
         'standardize_not_equals' => true,
         'static_lambda' => false,
         'strict_comparison' => true,


### PR DESCRIPTION
This PR

* [x] enables the `standardize_increment` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**standardize_increment** [`@Symfony`]
>
>Increment and decrement operators should be used if possible.