### PR TITLE
Enhancement: Enable string_line_ending fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -247,7 +247,7 @@ final class Php56 extends AbstractRuleSet
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => false,
         'trailing_comma_in_multiline_array' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -247,7 +247,7 @@ final class Php70 extends AbstractRuleSet
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -249,7 +249,7 @@ final class Php71 extends AbstractRuleSet
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -247,7 +247,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => false,
         'trailing_comma_in_multiline_array' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -247,7 +247,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -249,7 +249,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'static_lambda' => false,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_line_ending' => false,
+        'string_line_ending' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,


### PR DESCRIPTION
This PR

* [x] enables the `string_line_ending` fixer

Follows https://github.com/localheinz/php-cs-fixer-config/pull/116.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.11.0#usage:

>**string_line_ending**
>
>All multi-line strings must use correct line ending.
>
>*Risky rule: changing the line endings of multi-line strings might affect string comparisons and outputs.*