### PR TITLE
Enhancement: Enable and configure error_suppression fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -87,7 +87,10 @@ final class Php56 extends AbstractRuleSet
             'before_array_assignments_equals' => false,
         ],
         'ereg_to_preg' => true,
-        'error_suppression' => false,
+        'error_suppression' => [
+            'mute_deprecation_error' => true,
+            'noise_remaining_usages' => true,
+        ],
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -87,7 +87,10 @@ final class Php70 extends AbstractRuleSet
             'before_array_assignments_equals' => false,
         ],
         'ereg_to_preg' => true,
-        'error_suppression' => false,
+        'error_suppression' => [
+            'mute_deprecation_error' => true,
+            'noise_remaining_usages' => true,
+        ],
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -87,7 +87,10 @@ final class Php71 extends AbstractRuleSet
             'before_array_assignments_equals' => false,
         ],
         'ereg_to_preg' => true,
-        'error_suppression' => false,
+        'error_suppression' => [
+            'mute_deprecation_error' => true,
+            'noise_remaining_usages' => true,
+        ],
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -87,7 +87,10 @@ final class Php56Test extends AbstractRuleSetTestCase
             'before_array_assignments_equals' => false,
         ],
         'ereg_to_preg' => true,
-        'error_suppression' => false,
+        'error_suppression' => [
+            'mute_deprecation_error' => true,
+            'noise_remaining_usages' => true,
+        ],
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -87,7 +87,10 @@ final class Php70Test extends AbstractRuleSetTestCase
             'before_array_assignments_equals' => false,
         ],
         'ereg_to_preg' => true,
-        'error_suppression' => false,
+        'error_suppression' => [
+            'mute_deprecation_error' => true,
+            'noise_remaining_usages' => true,
+        ],
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -87,7 +87,10 @@ final class Php71Test extends AbstractRuleSetTestCase
             'before_array_assignments_equals' => false,
         ],
         'ereg_to_preg' => true,
-        'error_suppression' => false,
+        'error_suppression' => [
+            'mute_deprecation_error' => true,
+            'noise_remaining_usages' => true,
+        ],
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `error_suppression` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**error_suppression** [`@Symfony:risky`]
>
>Error control operator should be added to deprecation notices and/or removed from other cases.
>
>Risky rule: risky because adding/removing ``@`` might cause changes to code behaviour or if ``trigger_error`` function is overridden.
>
>Configuration options:
>
>* `mute_deprecation_error` (`bool`): whether to add `@` in deprecation notices; defaults to `true`
>* `noise_remaining_usages` (`bool`): whether to remove `@` in remaining usages; defaults to `false`
>* `noise_remaining_usages_exclude` (`array`): list of global functions to exclude from removing `@`; defaults to `[]`