### PR TITLE
Enhancement: Enable logical_operators fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -106,7 +106,7 @@ final class Php56 extends AbstractRuleSet
         'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
-        'logical_operators' => false,
+        'logical_operators' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => false,
         'magic_constant_casing' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -106,7 +106,7 @@ final class Php70 extends AbstractRuleSet
         'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
-        'logical_operators' => false,
+        'logical_operators' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => false,
         'magic_constant_casing' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -108,7 +108,7 @@ final class Php71 extends AbstractRuleSet
         'list_syntax' => [
             'syntax' => 'short',
         ],
-        'logical_operators' => false,
+        'logical_operators' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => false,
         'magic_constant_casing' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -106,7 +106,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
-        'logical_operators' => false,
+        'logical_operators' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => false,
         'magic_constant_casing' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -106,7 +106,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'is_null' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => false,
-        'logical_operators' => false,
+        'logical_operators' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => false,
         'magic_constant_casing' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -108,7 +108,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'list_syntax' => [
             'syntax' => 'short',
         ],
-        'logical_operators' => false,
+        'logical_operators' => true,
         'lowercase_cast' => true,
         'lowercase_static_reference' => false,
         'magic_constant_casing' => true,


### PR DESCRIPTION
This PR

* [x] enables the `logical_operators` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**logical_operators**
>
>Use `&&` and `||` logical operators instead of `and` and `or`.
>
>*Risky rule: risky, because you must double-check if using `and`/`or` with lower precedence was intentional.*