### PR TITLE
Enhancement: Enable lowercase_static_reference fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -108,7 +108,7 @@ final class Php56 extends AbstractRuleSet
         'list_syntax' => false,
         'logical_operators' => false,
         'lowercase_cast' => true,
-        'lowercase_static_reference' => false,
+        'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -108,7 +108,7 @@ final class Php70 extends AbstractRuleSet
         'list_syntax' => false,
         'logical_operators' => false,
         'lowercase_cast' => true,
-        'lowercase_static_reference' => false,
+        'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -110,7 +110,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'logical_operators' => false,
         'lowercase_cast' => true,
-        'lowercase_static_reference' => false,
+        'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -108,7 +108,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'list_syntax' => false,
         'logical_operators' => false,
         'lowercase_cast' => true,
-        'lowercase_static_reference' => false,
+        'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -108,7 +108,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'list_syntax' => false,
         'logical_operators' => false,
         'lowercase_cast' => true,
-        'lowercase_static_reference' => false,
+        'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -110,7 +110,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'logical_operators' => false,
         'lowercase_cast' => true,
-        'lowercase_static_reference' => false,
+        'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [


### PR DESCRIPTION
This PR

* [x] enables the `lowercase_static_reference` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**lowercase_static_reference** [`@Symfony`]
>
>Class static references `self`, `static` and `parent` MUST be in lower case.
