### PR TITLE
Enhancement: Enable native_constant_invocation fixer

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,10 +27,10 @@ final class Factory
      */
     public static function fromRuleSet(RuleSet $ruleSet, array $overrideRules = [])
     {
-        if (PHP_VERSION_ID < $ruleSet->targetPhpVersion()) {
+        if (\PHP_VERSION_ID < $ruleSet->targetPhpVersion()) {
             throw new \RuntimeException(\sprintf(
                 'Current PHP version "%s is less than targeted PHP version "%s".',
-                PHP_VERSION_ID,
+                \PHP_VERSION_ID,
                 $ruleSet->targetPhpVersion()
             ));
         }

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -125,7 +125,7 @@ final class Php56 extends AbstractRuleSet
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -125,7 +125,7 @@ final class Php70 extends AbstractRuleSet
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -127,7 +127,7 @@ final class Php71 extends AbstractRuleSet
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -26,7 +26,7 @@ final class FactoryTest extends Framework\TestCase
 
     public function testFromRuleSetThrowsRuntimeExceptionIfCurrentPhpVersionIsLessThanTargetPhpVersion()
     {
-        $targetPhpVersion = PHP_VERSION_ID + 1;
+        $targetPhpVersion = \PHP_VERSION_ID + 1;
 
         $ruleSet = $this->prophesize(Config\RuleSet::class);
 
@@ -46,7 +46,7 @@ final class FactoryTest extends Framework\TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf(
             'Current PHP version "%s is less than targeted PHP version "%s".',
-            PHP_VERSION_ID,
+            \PHP_VERSION_ID,
             $targetPhpVersion
         ));
 
@@ -100,8 +100,8 @@ final class FactoryTest extends Framework\TestCase
     public function providerTargetPhpVersion()
     {
         $values = [
-            PHP_VERSION_ID - 1,
-            PHP_VERSION_ID,
+            \PHP_VERSION_ID - 1,
+            \PHP_VERSION_ID,
         ];
 
         foreach ($values as $value) {
@@ -141,7 +141,7 @@ final class FactoryTest extends Framework\TestCase
         $ruleSet
             ->targetPhpVersion()
             ->shouldBeCalled()
-            ->willReturn(PHP_VERSION_ID);
+            ->willReturn(\PHP_VERSION_ID);
 
         $config = Config\Factory::fromRuleSet(
             $ruleSet->reveal(),

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -125,7 +125,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -125,7 +125,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -127,7 +127,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'multiline_whitespace_before_semicolons' => [
             'strategy' => 'no_multi_line',
         ],
-        'native_constant_invocation' => false,
+        'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
         'new_with_braces' => true,


### PR DESCRIPTION
This PR

* [x] enables the `native_constant_invocation` fixer
* [x] runs `make cs`

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**native_constant_invocation** [`@Symfony:risky`]
>
>Add leading `\` before constant invocation of internal constant to speed up resolving. Constant name match is case-sensitive, except for `null`, `false` and `true`.
>
>**Risky rule: risky when any of the constants are namespaced or overridden.**
>
>Configuration options:
>
>* `exclude` (`array`): list of constants to ignore; defaults to `['null', 'false', 'true']`
>* `fix_built_in` (`bool`): whether to fix constants returned by `get_defined_constants`. User constants are not accounted in this list and must be specified in the include one; defaults to `true`
>* `include` (`array`): list of additional constants to fix; defaults to `[]`
