### PR TITLE
Enhancement: Enable no_binary_string fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -131,7 +131,7 @@ final class Php56 extends AbstractRuleSet
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
-        'no_binary_string' => false,
+        'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -131,7 +131,7 @@ final class Php70 extends AbstractRuleSet
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
-        'no_binary_string' => false,
+        'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -133,7 +133,7 @@ final class Php71 extends AbstractRuleSet
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
-        'no_binary_string' => false,
+        'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -131,7 +131,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
-        'no_binary_string' => false,
+        'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -131,7 +131,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
-        'no_binary_string' => false,
+        'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -133,7 +133,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,
-        'no_binary_string' => false,
+        'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_blank_lines_before_namespace' => false,


### PR DESCRIPTION
This PR

* [x] enables the `no_binary_string` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**no_binary_string**
>
>There should not be a binary flag before strings.
