### PR TITLE
Enhancement: Enable no_unset_on_property fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -178,7 +178,7 @@ final class Php56 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => false,
+        'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -178,7 +178,7 @@ final class Php70 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => false,
+        'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -180,7 +180,7 @@ final class Php71 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => false,
+        'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -178,7 +178,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => false,
+        'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -178,7 +178,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => false,
+        'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -180,7 +180,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_on_property' => false,
+        'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_unset_on_property` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**no_unset_on_property**
>
>Properties should be set to `null` instead of using `unset`.
>
>**Risky rule: changing variables to ``null`` instead of unsetting them will mean they still show up when looping over class variables.**