### PR TITLE
Enhancement: Enable and configure php_unit_internal_class fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -197,7 +197,13 @@ final class Php56 extends AbstractRuleSet
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => false,
+        'php_unit_internal_class' => [
+            'types' => [
+                'abstract',
+                'final',
+                'normal',
+            ],
+        ],
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => '5.7',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -197,7 +197,13 @@ final class Php70 extends AbstractRuleSet
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => false,
+        'php_unit_internal_class' => [
+            'types' => [
+                'abstract',
+                'final',
+                'normal',
+            ],
+        ],
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -199,7 +199,13 @@ final class Php71 extends AbstractRuleSet
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => false,
+        'php_unit_internal_class' => [
+            'types' => [
+                'abstract',
+                'final',
+                'normal',
+            ],
+        ],
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -15,6 +15,9 @@ use Localheinz\PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
 use PHPUnit\Framework;
 
+/**
+ * @internal
+ */
 final class FactoryTest extends Framework\TestCase
 {
     public function testIsFinal()

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -17,6 +17,9 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet;
 use PHPUnit\Framework;
 
+/**
+ * @internal
+ */
 abstract class AbstractRuleSetTestCase extends Framework\TestCase
 {
     /**

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -197,7 +197,13 @@ final class Php56Test extends AbstractRuleSetTestCase
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => false,
+        'php_unit_internal_class' => [
+            'types' => [
+                'abstract',
+                'final',
+                'normal',
+            ],
+        ],
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => '5.7',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -11,6 +11,9 @@
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+/**
+ * @internal
+ */
 final class Php56Test extends AbstractRuleSetTestCase
 {
     protected $name = 'localheinz (PHP 5.6)';

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -197,7 +197,13 @@ final class Php70Test extends AbstractRuleSetTestCase
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => false,
+        'php_unit_internal_class' => [
+            'types' => [
+                'abstract',
+                'final',
+                'normal',
+            ],
+        ],
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -11,6 +11,9 @@
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+/**
+ * @internal
+ */
 final class Php70Test extends AbstractRuleSetTestCase
 {
     protected $name = 'localheinz (PHP 7.0)';

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -199,7 +199,13 @@ final class Php71Test extends AbstractRuleSetTestCase
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => false,
+        'php_unit_internal_class' => [
+            'types' => [
+                'abstract',
+                'final',
+                'normal',
+            ],
+        ],
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -11,6 +11,9 @@
 
 namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+/**
+ * @internal
+ */
 final class Php71Test extends AbstractRuleSetTestCase
 {
     protected $name = 'localheinz (PHP 7.1)';


### PR DESCRIPTION
This PR

* [x] enables and configures the `php_unit_internal_class` fixer
* [x] runs `make cs`

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

> **php_unit_internal_class**
>
>All PHPUnit test classes should be marked as internal.
>
>Configuration options:
>
>* `types` (a subset of `['normal', 'final', 'abstract']`): what types of classes to mark as internal; defaults to `['normal', 'final']`