### PR TITLE
Enhancement: Enable phpdoc_trim_consecutive_blank_line_separation fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -233,7 +233,7 @@ final class Php56 extends AbstractRuleSet
         'phpdoc_to_comment' => false,
         'phpdoc_to_return_type' => false,
         'phpdoc_trim' => true,
-        'phpdoc_trim_consecutive_blank_line_separation' => false,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_first',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -233,7 +233,7 @@ final class Php70 extends AbstractRuleSet
         'phpdoc_to_comment' => false,
         'phpdoc_to_return_type' => false,
         'phpdoc_trim' => true,
-        'phpdoc_trim_consecutive_blank_line_separation' => false,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_first',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -235,7 +235,7 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_to_comment' => false,
         'phpdoc_to_return_type' => false,
         'phpdoc_trim' => true,
-        'phpdoc_trim_consecutive_blank_line_separation' => false,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_first',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -233,7 +233,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'phpdoc_to_comment' => false,
         'phpdoc_to_return_type' => false,
         'phpdoc_trim' => true,
-        'phpdoc_trim_consecutive_blank_line_separation' => false,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_first',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -233,7 +233,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'phpdoc_to_comment' => false,
         'phpdoc_to_return_type' => false,
         'phpdoc_trim' => true,
-        'phpdoc_trim_consecutive_blank_line_separation' => false,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_first',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -235,7 +235,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_to_comment' => false,
         'phpdoc_to_return_type' => false,
         'phpdoc_trim' => true,
-        'phpdoc_trim_consecutive_blank_line_separation' => false,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
         'phpdoc_types' => true,
         'phpdoc_types_order' => [
             'null_adjustment' => 'always_first',


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_trim_consecutive_blank_line_separation` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**phpdoc_trim_consecutive_blank_line_separation**
>
>Removes extra blank lines after summary and after description in PHPDoc