### PR TITLE
Enhancement: Enable return_assignment fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -246,7 +246,7 @@ final class Php56 extends AbstractRuleSet
         'psr0' => false,
         'psr4' => true,
         'random_api_migration' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -246,7 +246,7 @@ final class Php70 extends AbstractRuleSet
         'psr0' => false,
         'psr4' => true,
         'random_api_migration' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -248,7 +248,7 @@ final class Php71 extends AbstractRuleSet
         'psr0' => false,
         'psr4' => true,
         'random_api_migration' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -246,7 +246,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'psr0' => false,
         'psr4' => true,
         'random_api_migration' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -246,7 +246,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'psr0' => false,
         'psr4' => true,
         'random_api_migration' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -248,7 +248,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'psr0' => false,
         'psr4' => true,
         'random_api_migration' => true,
-        'return_assignment' => false,
+        'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,


### PR DESCRIPTION
This PR

* [x] enables the `return_assignment` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**return_assignment**
>
>Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method.