### PR TITLE
Enhancement: Enable set_type_to_cast fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -250,7 +250,7 @@ final class Php56 extends AbstractRuleSet
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
         'simplified_null_return' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -250,7 +250,7 @@ final class Php70 extends AbstractRuleSet
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
         'simplified_null_return' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -252,7 +252,7 @@ final class Php71 extends AbstractRuleSet
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
         'simplified_null_return' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -250,7 +250,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
         'simplified_null_return' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -250,7 +250,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
         'simplified_null_return' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -252,7 +252,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'return_type_declaration' => true,
         'self_accessor' => true,
         'semicolon_after_instruction' => true,
-        'set_type_to_cast' => false,
+        'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
         'simplified_null_return' => false,


### PR DESCRIPTION
This PR

* [x] enables the `set_type_to_cast` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**set_type_to_cast** [`@Symfony:risky`]
>
>Cast shall be used, not `settype`.
>
>*Risky rule: risky when the ``settype`` function is overridden or when used as the 2nd or 3rd expression in a ``for`` loop .*