### PR TITLE
Fix: Use snake-case configuration key for header_comment fixer

### DIFF
--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -59,7 +59,7 @@ abstract class AbstractRuleSet implements RuleSet
         }
 
         $this->rules['header_comment'] = [
-            'commentType' => 'PHPDoc',
+            'comment_type' => 'PHPDoc',
             'header' => $header,
             'location' => 'after_declare_strict',
             'separate' => 'both',

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -179,7 +179,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         $this->assertArrayHasKey('header_comment', $rules);
 
         $expected = [
-            'commentType' => 'PHPDoc',
+            'comment_type' => 'PHPDoc',
             'header' => $header,
             'location' => 'after_declare_strict',
             'separate' => 'both',


### PR DESCRIPTION
This PR

* [x] uses the snake-case configuration key `comment_type` instead of the deprecated camel-case variant

Follows #127.