### PR TITLE
Enhancement: Use always_move_variable option for yoda_style fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -286,6 +286,7 @@ final class Php56 extends AbstractRuleSet
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
+            'always_move_variable' => true,
             'equal' => true,
             'identical' => true,
             'less_and_greater' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -286,6 +286,7 @@ final class Php70 extends AbstractRuleSet
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
+            'always_move_variable' => true,
             'equal' => true,
             'identical' => true,
             'less_and_greater' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -289,6 +289,7 @@ final class Php71 extends AbstractRuleSet
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
+            'always_move_variable' => true,
             'equal' => true,
             'identical' => true,
             'less_and_greater' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -289,6 +289,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
+            'always_move_variable' => true,
             'equal' => true,
             'identical' => true,
             'less_and_greater' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -289,6 +289,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
+            'always_move_variable' => true,
             'equal' => true,
             'identical' => true,
             'less_and_greater' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -292,6 +292,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'void_return' => false,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
+            'always_move_variable' => true,
             'equal' => true,
             'identical' => true,
             'less_and_greater' => true,


### PR DESCRIPTION
This PR

* [x] uses the `always_move_variable` option for the `yoda_style` fixer

Follows #127.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.12.0#usage:

>**yoda_style** [`@Symfony`]
>
>Write conditions in Yoda style (true), non-Yoda style (false) or ignore those conditions (null) based on configuration.
>
>Configuration options:
>
>* `always_move_variable` (`bool`): whether variables should always be on non assignable side when applying Yoda style; defaults to `false`
>* `equal` (`bool`, `null`): style for equal (`==`, `!=`) statements; defaults to `true`
>* `identical` (`bool`, `null`): style for identical (`===`, `!==`) statements; defaults to `true`
>* `less_and_greater` (`bool`, `null`): style for less and greater than (`<`, `<=`, `>`, `>=`) statements; defaults to `null`