### PR TITLE
Enhancement: Enable combine_nested_dirname fixer

### DIFF
--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -61,7 +61,7 @@ final class Php70 extends AbstractRuleSet
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => false,
         'concat_space' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -61,7 +61,7 @@ final class Php71 extends AbstractRuleSet
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -64,7 +64,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => false,
         'concat_space' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -64,7 +64,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'class_keyword_remove' => false,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'combine_nested_dirname' => false,
+        'combine_nested_dirname' => true,
         'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => [


### PR DESCRIPTION
This PR

* [x] enables the `combine_nested_dirname ` fixer

Follows #146.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.0#usage:

>**combine_nested_dirname** [`@PHP70Migration:risky`, `@PHP71Migration:risky`]
>
>Replace multiple nested calls of `dirname` by only one call with second `$level` parameter. Requires PHP >= 7.0.
>
>Risky rule: risky when the function ``dirname`` is overridden.