### PR TITLE
Enhancement: Enable fopen_flag_order fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -96,7 +96,7 @@ final class Php56 extends AbstractRuleSet
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fopen_flag_order' => false,
+        'fopen_flag_order' => true,
         'fopen_flags' => false,
         'fully_qualified_strict_types' => false,
         'function_to_constant' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -96,7 +96,7 @@ final class Php70 extends AbstractRuleSet
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fopen_flag_order' => false,
+        'fopen_flag_order' => true,
         'fopen_flags' => false,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -96,7 +96,7 @@ final class Php71 extends AbstractRuleSet
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fopen_flag_order' => false,
+        'fopen_flag_order' => true,
         'fopen_flags' => false,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -99,7 +99,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fopen_flag_order' => false,
+        'fopen_flag_order' => true,
         'fopen_flags' => false,
         'fully_qualified_strict_types' => false,
         'function_to_constant' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -99,7 +99,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fopen_flag_order' => false,
+        'fopen_flag_order' => true,
         'fopen_flags' => false,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -99,7 +99,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'final_internal_class' => true,
-        'fopen_flag_order' => false,
+        'fopen_flag_order' => true,
         'fopen_flags' => false,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,


### PR DESCRIPTION
This PR

* [x] enables the `fopen_flag_order` fixer

Follows #146.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.0#usage:

>**fopen_flag_order** [`@Symfony:risky`]
>
>Order the flags in `fopen` calls, `b` and `t` must be last.
>
>*Risky rule: risky when the function ``fopen`` is overridden.*
