### PR TITLE
Enhancement: Enable fopen_flags fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -97,7 +97,7 @@ final class Php56 extends AbstractRuleSet
         'explicit_string_variable' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
-        'fopen_flags' => false,
+        'fopen_flags' => true,
         'fully_qualified_strict_types' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -97,7 +97,7 @@ final class Php70 extends AbstractRuleSet
         'explicit_string_variable' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
-        'fopen_flags' => false,
+        'fopen_flags' => true,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -97,7 +97,7 @@ final class Php71 extends AbstractRuleSet
         'explicit_string_variable' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
-        'fopen_flags' => false,
+        'fopen_flags' => true,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -100,7 +100,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'explicit_string_variable' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
-        'fopen_flags' => false,
+        'fopen_flags' => true,
         'fully_qualified_strict_types' => false,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -100,7 +100,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'explicit_string_variable' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
-        'fopen_flags' => false,
+        'fopen_flags' => true,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -100,7 +100,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'explicit_string_variable' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
-        'fopen_flags' => false,
+        'fopen_flags' => true,
         'fully_qualified_strict_types' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,


### PR DESCRIPTION
This PR

* [x] enables the `fopen_flags` fixer

Follows #146.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.0#usage:

>**fopen_flags** [`@Symfony:risky`]
>
>The flags in `fopen` calls must contain `b` and must omit `t`.
>
>*Risky rule: risky when the function ``fopen`` is overridden.*