### PR TITLE
Enhancement: Enable implode_call fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -105,7 +105,7 @@ final class Php56 extends AbstractRuleSet
         'hash_to_slash_comment' => true,
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'pre',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -105,7 +105,7 @@ final class Php70 extends AbstractRuleSet
         'hash_to_slash_comment' => true,
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'pre',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -105,7 +105,7 @@ final class Php71 extends AbstractRuleSet
         'hash_to_slash_comment' => true,
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'pre',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -108,7 +108,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'hash_to_slash_comment' => true,
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'pre',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -108,7 +108,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'hash_to_slash_comment' => true,
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'pre',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -108,7 +108,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'hash_to_slash_comment' => true,
         'header_comment' => false,
         'heredoc_to_nowdoc' => true,
-        'implode_call' => false,
+        'implode_call' => true,
         'include' => true,
         'increment_style' => [
             'style' => 'pre',


### PR DESCRIPTION
This PR

* [x] enables the `implode_call` fixer

Follows #146.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.0#usage:

>**implode_call** [`@Symfony:risky`]
>
>Function `implode` must be called with 2 arguments in the documented order.
>
>*Risky rule: risky when the function ``implode`` is overridden.*