### PR TITLE
Enhancement: Enable magic_method_casing fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -117,7 +117,7 @@ final class Php56 extends AbstractRuleSet
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
-        'magic_method_casing' => false,
+        'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
             'ensure_fully_multiline' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -117,7 +117,7 @@ final class Php70 extends AbstractRuleSet
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
-        'magic_method_casing' => false,
+        'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
             'ensure_fully_multiline' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -119,7 +119,7 @@ final class Php71 extends AbstractRuleSet
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
-        'magic_method_casing' => false,
+        'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
             'ensure_fully_multiline' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -120,7 +120,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
-        'magic_method_casing' => false,
+        'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
             'ensure_fully_multiline' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -120,7 +120,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
-        'magic_method_casing' => false,
+        'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
             'ensure_fully_multiline' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -122,7 +122,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'lowercase_cast' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
-        'magic_method_casing' => false,
+        'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
             'ensure_fully_multiline' => true,


### PR DESCRIPTION
This PR

* [x] enables the `magic_method_casing` fixer

Follows #146.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.0#usage:

>magic_method_casing [`@Symfony`]
>
>Magic method definitions and calls must be using the correct casing.