### PR TITLE
Enhancement: Enable php_unit_method_casing fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -209,7 +209,7 @@ final class Php56 extends AbstractRuleSet
                 'normal',
             ],
         ],
-        'php_unit_method_casing' => false,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => '5.7',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -209,7 +209,7 @@ final class Php70 extends AbstractRuleSet
                 'normal',
             ],
         ],
-        'php_unit_method_casing' => false,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -211,7 +211,7 @@ final class Php71 extends AbstractRuleSet
                 'normal',
             ],
         ],
-        'php_unit_method_casing' => false,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -212,7 +212,7 @@ final class Php56Test extends AbstractRuleSetTestCase
                 'normal',
             ],
         ],
-        'php_unit_method_casing' => false,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => '5.7',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -212,7 +212,7 @@ final class Php70Test extends AbstractRuleSetTestCase
                 'normal',
             ],
         ],
-        'php_unit_method_casing' => false,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -214,7 +214,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'normal',
             ],
         ],
-        'php_unit_method_casing' => false,
+        'php_unit_method_casing' => true,
         'php_unit_mock' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_method_casing` fixer

Follows #146.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.0#usage:

>**php_unit_method_casing**
>
>Enforce camel (or snake) case for PHPUnit test methods, following configuration.
>
>Configuration options:
>
>* `case` (`'camel_case'`, `'snake_case'`): apply camel or snake case to test methods; defaults to `'camel_case'`