### PR TITLE
Enhancement: Enable static_lambda fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -274,7 +274,7 @@ final class Php56 extends AbstractRuleSet
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => false,
+        'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -274,7 +274,7 @@ final class Php70 extends AbstractRuleSet
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => false,
+        'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -276,7 +276,7 @@ final class Php71 extends AbstractRuleSet
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => false,
+        'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -265,7 +265,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
             $fixerFactory = FixerFactory::create();
             $fixerFactory->registerBuiltInFixers();
 
-            $builtInFixers = \array_map(function (Fixer\FixerInterface $fixer) {
+            $builtInFixers = \array_map(static function (Fixer\FixerInterface $fixer) {
                 return $fixer->getName();
             }, $fixerFactory->getFixers());
         }
@@ -283,7 +283,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
          *
          * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2361
          */
-        $rules = \array_map(function () {
+        $rules = \array_map(static function () {
             return true;
         }, $this->createRuleSet()->rules());
 

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -277,7 +277,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => false,
+        'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -277,7 +277,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => false,
+        'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -279,7 +279,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'static_lambda' => false,
+        'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'string_line_ending' => true,


### PR DESCRIPTION
This PR

* [x] enables the `static_lambda` fixer
* [ ] runs `make cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.1#usage:

>**static_lambda**
>
>Lambdas not (indirect) referencing `$this` must be declared `static`.
>
>*Risky rule: risky when using `->bindTo` on lambdas without referencing to ``$this``.*

