### PR TITLE
Enhancement: Configure php_unit_test_case_static_method_calls fixer to use self call type

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -223,7 +223,7 @@ final class Php56 extends AbstractRuleSet
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this',
+            'call_type' => 'self',
         ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -223,7 +223,7 @@ final class Php70 extends AbstractRuleSet
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this',
+            'call_type' => 'self',
         ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -225,7 +225,7 @@ final class Php71 extends AbstractRuleSet
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this',
+            'call_type' => 'self',
         ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -24,7 +24,7 @@ final class FactoryTest extends Framework\TestCase
     {
         $reflection = new \ReflectionClass(Config\Factory::class);
 
-        $this->assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     public function testFromRuleSetThrowsRuntimeExceptionIfCurrentPhpVersionIsLessThanTargetPhpVersion()
@@ -91,10 +91,10 @@ final class FactoryTest extends Framework\TestCase
 
         $config = Config\Factory::fromRuleSet($ruleSet->reveal());
 
-        $this->assertInstanceOf(ConfigInterface::class, $config);
-        $this->assertTrue($config->getUsingCache());
-        $this->assertTrue($config->getRiskyAllowed());
-        $this->assertSame($rules, $config->getRules());
+        self::assertInstanceOf(ConfigInterface::class, $config);
+        self::assertTrue($config->getUsingCache());
+        self::assertTrue($config->getRiskyAllowed());
+        self::assertSame($rules, $config->getRules());
     }
 
     /**
@@ -151,9 +151,9 @@ final class FactoryTest extends Framework\TestCase
             $overrideRules
         );
 
-        $this->assertInstanceOf(ConfigInterface::class, $config);
-        $this->assertTrue($config->getUsingCache());
-        $this->assertTrue($config->getRiskyAllowed());
-        $this->assertSame(\array_merge($rules, $overrideRules), $config->getRules());
+        self::assertInstanceOf(ConfigInterface::class, $config);
+        self::assertTrue($config->getUsingCache());
+        self::assertTrue($config->getRiskyAllowed());
+        self::assertSame(\array_merge($rules, $overrideRules), $config->getRules());
     }
 }

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -41,23 +41,23 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     {
         $reflection = new \ReflectionClass($this->className());
 
-        $this->assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     final public function testImplementsRuleSetInterface()
     {
         $reflection = new \ReflectionClass($this->className());
 
-        $this->assertTrue($reflection->implementsInterface(Config\RuleSet::class));
+        self::assertTrue($reflection->implementsInterface(Config\RuleSet::class));
     }
 
     final public function testDefaults()
     {
         $ruleSet = $this->createRuleSet();
 
-        $this->assertSame($this->name, $ruleSet->name());
-        $this->assertEquals($this->rules, $ruleSet->rules());
-        $this->assertEquals($this->targetPhpVersion, $ruleSet->targetPhpVersion());
+        self::assertSame($this->name, $ruleSet->name());
+        self::assertEquals($this->rules, $ruleSet->rules());
+        self::assertEquals($this->targetPhpVersion, $ruleSet->targetPhpVersion());
     }
 
     final public function testAllConfiguredRulesAreBuiltIn()
@@ -69,7 +69,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
         \sort($fixersNotBuiltIn);
 
-        $this->assertEmpty($fixersNotBuiltIn, \sprintf(
+        self::assertEmpty($fixersNotBuiltIn, \sprintf(
             'Failed to assert that fixers for the rules "%s" are built in',
             \implode('", "', $fixersNotBuiltIn)
         ));
@@ -84,7 +84,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
         \sort($fixersWithoutConfiguration);
 
-        $this->assertEmpty($fixersWithoutConfiguration, \sprintf(
+        self::assertEmpty($fixersWithoutConfiguration, \sprintf(
             'Failed to assert that built-in fixers for the rules "%s" are configured',
             \implode('", "', $fixersWithoutConfiguration)
         ));
@@ -131,8 +131,8 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     {
         $rules = $this->createRuleSet()->rules();
 
-        $this->assertArrayHasKey('header_comment', $rules);
-        $this->assertFalse($rules['header_comment']);
+        self::assertArrayHasKey('header_comment', $rules);
+        self::assertFalse($rules['header_comment']);
     }
 
     /**
@@ -144,7 +144,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     {
         $rules = $this->createRuleSet($header)->rules();
 
-        $this->assertArrayHasKey('header_comment', $rules);
+        self::assertArrayHasKey('header_comment', $rules);
 
         $expected = [
             'comment_type' => 'PHPDoc',
@@ -153,7 +153,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
             'separate' => 'both',
         ];
 
-        $this->assertSame($expected, $rules['header_comment']);
+        self::assertSame($expected, $rules['header_comment']);
     }
 
     /**
@@ -188,7 +188,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
         \sort($sorted);
 
-        $this->assertEquals($sorted, $ruleNames, \sprintf(
+        self::assertEquals($sorted, $ruleNames, \sprintf(
             'Failed to assert that the rules are sorted by name in %s',
             $source
         ));

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -226,7 +226,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this',
+            'call_type' => 'self',
         ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -226,7 +226,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this',
+            'call_type' => 'self',
         ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -228,7 +228,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'php_unit_strict' => false,
         'php_unit_test_annotation' => true,
         'php_unit_test_case_static_method_calls' => [
-            'call_type' => 'this',
+            'call_type' => 'self',
         ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [


### PR DESCRIPTION
This PR

* [x] configures the `php_unit_test_case_static_method_calls` fixer to use `self` as call type
* [x] runs `make cs`

💁‍♂️ This makes it easier to also use `phpstan/phpstan-strict-rules` for test code