### PR TITLE
Enhancement: Enable void_return fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -296,7 +296,7 @@ final class Php71 extends AbstractRuleSet
                 'property',
             ],
         ],
-        'void_return' => false,
+        'void_return' => true,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
             'always_move_variable' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -299,7 +299,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'property',
             ],
         ],
-        'void_return' => false,
+        'void_return' => true,
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => [
             'always_move_variable' => true,


### PR DESCRIPTION
This PR

* [x] enables the `void_return` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.1#usage:

>Add `void` return type to functions with missing or empty `return` statements, but priority is given to `@return` annotations. Requires PHP >= 7.1.
>
>*Risky rule: modifies the signature of functions.*