### PR TITLE
Enhancement: Enable heredoc_indentation fixer

### DIFF
--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -108,7 +108,7 @@ final class Php73 extends AbstractRuleSet
         'general_phpdoc_annotation_remove' => false,
         'hash_to_slash_comment' => true,
         'header_comment' => false,
-        'heredoc_indentation' => false,
+        'heredoc_indentation' => true,
         'heredoc_to_nowdoc' => true,
         'implode_call' => true,
         'include' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -111,7 +111,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'general_phpdoc_annotation_remove' => false,
         'hash_to_slash_comment' => true,
         'header_comment' => false,
-        'heredoc_indentation' => false,
+        'heredoc_indentation' => true,
         'heredoc_to_nowdoc' => true,
         'implode_call' => true,
         'include' => true,


### PR DESCRIPTION
This PR

* [x] enables the `heredoc_indentation` fixer

Follows #165.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.14.0#usage:

>**heredoc_indentation**
>
>Heredoc/nowdoc content must be properly indented. Requires PHP >= 7.3.