### PR TITLE
Enhancement: Enable no_unset_cast fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -188,7 +188,7 @@ final class Php56 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -188,7 +188,7 @@ final class Php70 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -190,7 +190,7 @@ final class Php71 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -190,7 +190,7 @@ final class Php73 extends AbstractRuleSet
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -191,7 +191,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -191,7 +191,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -193,7 +193,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -193,7 +193,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
         'no_unreachable_default_argument_value' => true,
-        'no_unset_cast' => false,
+        'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_unset_cast ` fixer

Follows #165.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.14.0#usage:

>**no_unset_cast** `[@PhpCsFixer]`
>
>Variables must be set `null` instead of using `(unset)` casting.