### PR TITLE
Enhancement: Enable phpdoc_var_annotation_correct_order fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -259,7 +259,7 @@ final class Php56 extends AbstractRuleSet
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -259,7 +259,7 @@ final class Php70 extends AbstractRuleSet
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -261,7 +261,7 @@ final class Php71 extends AbstractRuleSet
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -261,7 +261,7 @@ final class Php73 extends AbstractRuleSet
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -262,7 +262,7 @@ final class Php56Test extends AbstractRuleSetTestCase
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -262,7 +262,7 @@ final class Php70Test extends AbstractRuleSetTestCase
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -264,7 +264,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -264,7 +264,7 @@ final class Php73Test extends AbstractRuleSetTestCase
             'null_adjustment' => 'always_first',
             'sort_algorithm' => 'alpha',
         ],
-        'phpdoc_var_annotation_correct_order' => false,
+        'phpdoc_var_annotation_correct_order' => true,
         'phpdoc_var_without_name' => true,
         'pow_to_exponentiation' => true,
         'pre_increment' => false,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_var_annotation_correct_order` fixer

Follows #165.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.14.0#usage:

>**phpdoc_var_annotation_correct_order** `[@PhpCsFixer]`
>
>`@var` and `@type` annotations must have type and name in the correct order.