### PR TITLE
Fix: Add Php73 rule set to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Pick one of the rule sets:
 * `Localheinz\PhpCsFixer\RuleSet\Php56`
 * `Localheinz\PhpCsFixer\RuleSet\Php70`
 * `Localheinz\PhpCsFixer\RuleSet\Php71`
+* `Localheinz\PhpCsFixer\RuleSet\Php73`
 
 Create a configuration file `.php_cs` in the root of your project:
 


### PR DESCRIPTION
This PR

* [x] adds the `Php73` rule set to `README.md`

Follows #167.