### PR TITLE
Fix: Do not self-update composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,5 @@ test: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer self-update
 	composer validate
 	composer install

--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Create a `Makefile` with a `cs` target:
 .PHONY: composer cs
 
 composer: composer.json composer.lock
-	composer self-update
 	composer validate
 	composer install
 


### PR DESCRIPTION
This PR

* [x] stops self-updating `composer` in `vendor` target, and suggesting the same in `README.md`