### PR TITLE
Enhancement: Enable php_unit_test_class_requires_covers fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -231,7 +231,7 @@ final class Php56 extends AbstractRuleSet
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -231,7 +231,7 @@ final class Php70 extends AbstractRuleSet
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -233,7 +233,7 @@ final class Php71 extends AbstractRuleSet
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -233,7 +233,7 @@ final class Php73 extends AbstractRuleSet
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
+ * @covers \Localheinz\PhpCsFixer\Config\Factory
  */
 final class FactoryTest extends Framework\TestCase
 {

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -234,7 +234,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -13,6 +13,8 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
 /**
  * @internal
+ *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php56
  */
 final class Php56Test extends AbstractRuleSetTestCase
 {

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -234,7 +234,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -13,6 +13,8 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
 /**
  * @internal
+ *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php70
  */
 final class Php70Test extends AbstractRuleSetTestCase
 {

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -236,7 +236,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -13,6 +13,8 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
 /**
  * @internal
+ *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php71
  */
 final class Php71Test extends AbstractRuleSetTestCase
 {

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -236,7 +236,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
         ],
-        'php_unit_test_class_requires_covers' => false,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => false,
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -13,6 +13,8 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 
 /**
  * @internal
+ *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php73
  */
 final class Php73Test extends AbstractRuleSetTestCase
 {


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_test_class_requires_covers` fixer
* [x] adds missing `@covers` annotations

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.14.2.

>**php_unit_test_class_requires_covers** [`@PhpCsFixer`]
>
>Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.