### PR TITLE
Fix: Add missing covers annotation

### DIFF
--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -14,6 +14,7 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 /**
  * @internal
  *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\AbstractRuleSet
  * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php56
  */
 final class Php56Test extends AbstractRuleSetTestCase

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -14,6 +14,7 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 /**
  * @internal
  *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\AbstractRuleSet
  * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php70
  */
 final class Php70Test extends AbstractRuleSetTestCase

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -14,6 +14,7 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 /**
  * @internal
  *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\AbstractRuleSet
  * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php71
  */
 final class Php71Test extends AbstractRuleSetTestCase

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -14,6 +14,7 @@ namespace Localheinz\PhpCsFixer\Config\Test\Unit\RuleSet;
 /**
  * @internal
  *
+ * @covers \Localheinz\PhpCsFixer\Config\RuleSet\AbstractRuleSet
  * @covers \Localheinz\PhpCsFixer\Config\RuleSet\Php73
  */
 final class Php73Test extends AbstractRuleSetTestCase


### PR DESCRIPTION
This PR

* [x] adds missing `@covers` annotations

Follows #181.