### PR TITLE
Enhancement: Enable final_class fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -99,7 +99,7 @@ final class Php56 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -99,7 +99,7 @@ final class Php70 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -99,7 +99,7 @@ final class Php71 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -99,7 +99,7 @@ final class Php73 extends AbstractRuleSet
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -104,7 +104,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => false,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -104,7 +104,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -104,7 +104,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -104,7 +104,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
-        'final_class' => false,
+        'final_class' => true,
         'final_internal_class' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,


### PR DESCRIPTION
This PR

* [x] enables the `final_class` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

>All classes must be `final`, except abstract ones and Doctrine entities.
>
>**Risky rule: risky when subclassing non-abstract classes.**