### PR TITLE
Enhancement: Enable native_function_type_declaration_casing fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -139,7 +139,7 @@ final class Php56 extends AbstractRuleSet
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -139,7 +139,7 @@ final class Php70 extends AbstractRuleSet
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -141,7 +141,7 @@ final class Php71 extends AbstractRuleSet
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -141,7 +141,7 @@ final class Php73 extends AbstractRuleSet
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -144,7 +144,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -144,7 +144,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -146,7 +146,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -146,7 +146,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
-        'native_function_type_declaration_casing' => false,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,


### PR DESCRIPTION
This PR

* [x] enables the `native_function_type_declaration_casing` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

>**native_function_type_declaration_casing** [`@Symfony`, `@PhpCsFixer`]
>
>Native type hints for functions should use the correct case.