### PR TITLE
Enhancement: Enable ordered_interfaces fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -204,7 +204,7 @@ final class Php56 extends AbstractRuleSet
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -204,7 +204,7 @@ final class Php70 extends AbstractRuleSet
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -206,7 +206,7 @@ final class Php71 extends AbstractRuleSet
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -206,7 +206,7 @@ final class Php73 extends AbstractRuleSet
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -209,7 +209,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -209,7 +209,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -211,7 +211,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -211,7 +211,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
-        'ordered_interfaces' => false,
+        'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'php_unit_dedicate_assert_internal_type' => false,


### PR DESCRIPTION
This PR

* [x] enables the `ordered_interfaces` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

> **ordered_interfaces**
>
>Orders the interfaces in an `implements` or interface `extends` clause.
> 
> *Risky rule: risky for `implements` when specifying both an interface and its parent interface, because PHP doesn't break on `parent, child` but does on `child, parent`.*
>
>Configuration options:
>
>* `direction` (`'ascend'`, `'descend'`): which direction the interfaces should be ordered; defaults to `'ascend'`
>* `order` (`'alpha'`, `'length'`): how the interfaces should be ordered; defaults to `'alpha'`