### PR TITLE
Enhancement: Enable php_unit_dedicate_assert_internal_type fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -209,7 +209,7 @@ final class Php71 extends AbstractRuleSet
         'ordered_interfaces' => false,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_dedicate_assert_internal_type' => false,
+        'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_expectation' => [
             'target' => 'newest',
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -209,7 +209,7 @@ final class Php73 extends AbstractRuleSet
         'ordered_interfaces' => false,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_dedicate_assert_internal_type' => false,
+        'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_expectation' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -214,7 +214,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'ordered_interfaces' => false,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_dedicate_assert_internal_type' => false,
+        'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_expectation' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -214,7 +214,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'ordered_interfaces' => false,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
-        'php_unit_dedicate_assert_internal_type' => false,
+        'php_unit_dedicate_assert_internal_type' => true,
         'php_unit_expectation' => [
             'target' => 'newest',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_dedicate_assert_internal_type` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

>**php_unit_dedicate_assert_internal_type** [`@PHPUnit75Migration:risky`]
>
>PHPUnit assertions like `assertIsArray` should be used over `assertInternalType`.
>
>*Risky rule: risky when PHPUnit methods are overridden or when project has PHPUnit incompatibilities.*
>
>Configuration options:
>
>* `target` (`'7.5'`, `'newest'`): target version of PHPUnit; defaults to `'newest'`