### PR TITLE
Enhancement: Enable php_unit_mock_short_will_return fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -221,7 +221,7 @@ final class Php56 extends AbstractRuleSet
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => '5.7',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -221,7 +221,7 @@ final class Php70 extends AbstractRuleSet
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -223,7 +223,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -223,7 +223,7 @@ final class Php73 extends AbstractRuleSet
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -227,7 +227,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => '5.7',
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -227,7 +227,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -229,7 +229,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -229,7 +229,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         ],
         'php_unit_method_casing' => true,
         'php_unit_mock' => true,
-        'php_unit_mock_short_will_return' => false,
+        'php_unit_mock_short_will_return' => true,
         'php_unit_namespaced' => [
             'target' => 'newest',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_mock_short_will_return` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

>**php_unit_mock_short_will_return** [`@Symfony:risky`, `@PhpCsFixer:risky`]
>
>Usage of PHPUnit's mock e.g. `->will($this->returnValue(..))` must be replaced by its shorter equivalent such as `->willReturn(...)`.
>
>*Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.*