### PR TITLE
Enhancement: Enable simple_to_complex_string_variable fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -280,7 +280,7 @@ final class Php56 extends AbstractRuleSet
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => true,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -280,7 +280,7 @@ final class Php70 extends AbstractRuleSet
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => false,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -282,7 +282,7 @@ final class Php71 extends AbstractRuleSet
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => false,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -282,7 +282,7 @@ final class Php73 extends AbstractRuleSet
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => false,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -286,7 +286,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => true,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -286,7 +286,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => false,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -288,7 +288,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => false,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -288,7 +288,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,
         'silenced_deprecation_error' => false,
-        'simple_to_complex_string_variable' => false,
+        'simple_to_complex_string_variable' => true,
         'simplified_null_return' => false,
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,


### PR DESCRIPTION
This PR

* [x] enables the `simple_to_complex_string_variable` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

>**simple_to_complex_string_variable** [`@PhpCsFixer`]
>
>Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`).
