### PR TITLE
Enhancement: Enable single_trait_insert_per_statement fixer

### DIFF
--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -285,7 +285,7 @@ final class Php56 extends AbstractRuleSet
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -285,7 +285,7 @@ final class Php70 extends AbstractRuleSet
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -287,7 +287,7 @@ final class Php71 extends AbstractRuleSet
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -287,7 +287,7 @@ final class Php73 extends AbstractRuleSet
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -291,7 +291,7 @@ final class Php56Test extends AbstractRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -291,7 +291,7 @@ final class Php70Test extends AbstractRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -293,7 +293,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -293,7 +293,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_line_comment_style' => false,
         'single_quote' => true,
-        'single_trait_insert_per_statement' => false,
+        'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => true,
         'standardize_increment' => true,
         'standardize_not_equals' => true,


### PR DESCRIPTION
This PR

* [x] enables the `single_trait_insert_per_statement` fixer

Follows #180.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.0#usage:

>**single_trait_insert_per_statement** [`@Symfony`, `@PhpCsFixer`]
>
>Each trait `use` must be done as single statement.