### PR TITLE
Fix: Do not export .dependabot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.dependabot/       export-ignore
 /.github/           export-ignore
 /.travis/           export-ignore
 /test               export-ignore


### PR DESCRIPTION
This PR

* [x] ignores `.dependabot` when exporting