### PR TITLE
Fix: Disable method_separation fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -134,7 +134,7 @@ final class Php71 extends AbstractRuleSet
             'keep_multiple_spaces_after_comma' => false,
         ],
         'method_chaining_indentation' => true,
-        'method_separation' => true,
+        'method_separation' => false,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -134,7 +134,7 @@ final class Php73 extends AbstractRuleSet
             'keep_multiple_spaces_after_comma' => false,
         ],
         'method_chaining_indentation' => true,
-        'method_separation' => true,
+        'method_separation' => false,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -140,7 +140,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'keep_multiple_spaces_after_comma' => false,
         ],
         'method_chaining_indentation' => true,
-        'method_separation' => true,
+        'method_separation' => false,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -140,7 +140,7 @@ final class Php73Test extends AbstractRuleSetTestCase
             'keep_multiple_spaces_after_comma' => false,
         ],
         'method_chaining_indentation' => true,
-        'method_separation' => true,
+        'method_separation' => false,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [


### PR DESCRIPTION
This PR

* [x] disables the deprecated `method_separation` fixer

💁‍♂ It has been replaced by the `class_attributes_separation` which has already been configured properly.