### PR TITLE
Enhancement: Enable final_public_method_for_abstract_class fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -103,7 +103,7 @@ final class Php71 extends AbstractRuleSet
         'explicit_string_variable' => true,
         'final_class' => true,
         'final_internal_class' => true,
-        'final_public_method_for_abstract_class' => false,
+        'final_public_method_for_abstract_class' => true,
         'final_static_access' => false,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -103,7 +103,7 @@ final class Php73 extends AbstractRuleSet
         'explicit_string_variable' => true,
         'final_class' => true,
         'final_internal_class' => true,
-        'final_public_method_for_abstract_class' => false,
+        'final_public_method_for_abstract_class' => true,
         'final_static_access' => false,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -109,7 +109,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'explicit_string_variable' => true,
         'final_class' => true,
         'final_internal_class' => true,
-        'final_public_method_for_abstract_class' => false,
+        'final_public_method_for_abstract_class' => true,
         'final_static_access' => false,
         'fopen_flag_order' => true,
         'fopen_flags' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -109,7 +109,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'explicit_string_variable' => true,
         'final_class' => true,
         'final_internal_class' => true,
-        'final_public_method_for_abstract_class' => false,
+        'final_public_method_for_abstract_class' => true,
         'final_static_access' => false,
         'fopen_flag_order' => true,
         'fopen_flags' => true,


### PR DESCRIPTION
This PR

* [x] enables the `final_public_method_for_abstract_class` fixer

Follows #213.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.0#usage:

>**final_public_method_for_abstract_class**
>
>All `public` methods of `abstract` classes should be `final`.
>
>*Risky rule: risky when overriding `public` methods of `abstract` classes.*