### PR TITLE
Enhancement: Enable final_static_access fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -104,7 +104,7 @@ final class Php71 extends AbstractRuleSet
         'final_class' => true,
         'final_internal_class' => true,
         'final_public_method_for_abstract_class' => true,
-        'final_static_access' => false,
+        'final_static_access' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,
         'fully_qualified_strict_types' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -104,7 +104,7 @@ final class Php73 extends AbstractRuleSet
         'final_class' => true,
         'final_internal_class' => true,
         'final_public_method_for_abstract_class' => true,
-        'final_static_access' => false,
+        'final_static_access' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,
         'fully_qualified_strict_types' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -110,7 +110,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'final_class' => true,
         'final_internal_class' => true,
         'final_public_method_for_abstract_class' => true,
-        'final_static_access' => false,
+        'final_static_access' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,
         'fully_qualified_strict_types' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -110,7 +110,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'final_class' => true,
         'final_internal_class' => true,
         'final_public_method_for_abstract_class' => true,
-        'final_static_access' => false,
+        'final_static_access' => true,
         'fopen_flag_order' => true,
         'fopen_flags' => true,
         'fully_qualified_strict_types' => true,


### PR DESCRIPTION
This PR

* [x] enables the `final_static_access` fixer

Follows #213.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.0#usage:

>Converts `static` access to `self` access in `final` classes.
