### PR TITLE
Enhancement: Enable nullable_type_declaration_for_default_null_value fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -209,7 +209,7 @@ final class Php71 extends AbstractRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -209,7 +209,7 @@ final class Php73 extends AbstractRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -215,7 +215,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -215,7 +215,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration_for_default_null_value' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,


### PR DESCRIPTION
This PR

* [x] enables the `nullable_type_declaration_for_default_null_value` fixer

Follows #213.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.0#usage:

>**nullable_type_declaration_for_default_null_value**
>
>Adds or removes `?` before type declarations for parameters with a default `null` value.
>
>Configuration options:
>
>* `use_nullable_type_declaration` (`bool`): whether to add or remove `?` before type declarations for parameters with a default `null` value; defaults to `true`