### PR TITLE
Enhancement: Enable and configure phpdoc_line_span fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -254,7 +254,11 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -254,7 +254,11 @@ final class Php73 extends AbstractRuleSet
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -260,7 +260,11 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -260,7 +260,11 @@ final class Php73Test extends AbstractRuleSetTestCase
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_inline_tag' => true,
-        'phpdoc_line_span' => false,
+        'phpdoc_line_span' => [
+            'const' => 'multi',
+            'method' => 'multi',
+            'property' => 'multi',
+        ],
         'phpdoc_no_access' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_line_span` fixer

Follows #213.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.0#usage:

>**phpdoc_line_span**
>
>Changes doc blocks from single to multi line, or reversed. Works for class constants, properties and methods only.
>
>Configuration options:
>
>* `const` (`'multi'`, `'single'`): whether const blocks should be single or multi line; defaults to `'multi'`
>* `method` (`'multi'`, `'single'`): whether method doc blocks should be single or multi line; defaults to `'multi'`
>* `property` (`'multi'`, `'single'`): whether property doc blocks should be single or multi line; defaults to `'multi'`