### PR TITLE
Enhancement: Enable self_static_accessor fixer

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -291,7 +291,7 @@ final class Php71 extends AbstractRuleSet
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -291,7 +291,7 @@ final class Php73 extends AbstractRuleSet
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -297,7 +297,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -297,7 +297,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'return_assignment' => true,
         'return_type_declaration' => true,
         'self_accessor' => true,
-        'self_static_accessor' => false,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,


### PR DESCRIPTION
This PR

* [x] enables the `self_static_accessor` fixer

Follows #213.

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.0#usage:

>**self_static_accessor**
>
>Inside a `final` class or anonymous class `self` should be preferred to `static`.